### PR TITLE
feat: add trusted repository review configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,6 @@ npm run format:check
 
 Add deterministic unit coverage for new behavior. Do not make tests call GitHub or OpenAI. Update README and the relevant `docs/` page when public behavior changes.
 
+When changing repository configuration, preserve the trusted-base-commit boundary and add tests for invalid input and CLI precedence.
+
 Pull requests should explain the behavior change, test evidence, security implications, and known limitations. Keep changes small and reviewable.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Deduplicate identical findings and apply deterministic severity filtering.
 - Print Markdown to stdout or write it to `--output`.
 - Run lint, typecheck, tests, and build in GitHub Actions without secrets.
+- Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 
 ## How It Works
 
@@ -77,6 +78,19 @@ OPENAI_API_KEY=
 ```
 
 `OPENAI_API_KEY` is required for an AI review. Never commit `.env` or place real credentials in examples, issues, reports, or logs.
+
+### Repository configuration
+
+v0.2 supports an optional `.oss-pr-reviewer.yml` file:
+
+```yaml
+version: 1
+
+review:
+  minSeverity: medium
+```
+
+The file is loaded from the pull request's base commit, not the PR branch, so a PR cannot silently change the policy used to review itself. CLI options override repository configuration, and configuration overrides application defaults. See [docs/configuration.md](docs/configuration.md) and [examples/oss-pr-reviewer.yml](examples/oss-pr-reviewer.yml).
 
 ## CLI Usage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,8 @@ CLI
   |
 GitHub Client
   |
+Trusted base-branch configuration
+  |
 PR normalization
   |
 Deterministic batching
@@ -26,6 +28,7 @@ Markdown renderer
 
 - `src/cli/` validates command options, loads configuration, runs the workflow, and handles user-facing errors.
 - `src/github/` owns Octokit access and converts GitHub responses into the internal pull request model. API failures are normalized into concise errors.
+- `src/config/repository.ts` validates optional `.oss-pr-reviewer.yml` content loaded from the pull request base SHA. PR-head configuration is never used as active policy.
 - `src/review/normalize.ts` removes binary and patchless files from AI input while preserving skip reasons for the report.
 - `src/review/batching.ts` applies the centralized `maxDiffSize`, `maxFileSize`, and `maxFilesPerBatch` limits.
 - `src/ai/` contains the OpenAI SDK boundary. The rest of the review engine depends on the small `ReviewProvider` interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,33 @@
+# Repository Configuration
+
+v0.2 supports an optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes.
+
+## Example
+
+```yaml
+version: 1
+
+review:
+  minSeverity: medium
+```
+
+The currently supported settings are:
+
+- `version`: must be `1`.
+- `review.minSeverity`: optional `low`, `medium`, `high`, or `critical` value.
+
+If the file is absent, v0.1 behavior is preserved and the default minimum severity is `low`. Invalid YAML, unsupported keys, unsupported versions, or invalid values fail the review with an actionable configuration error; they are not silently ignored.
+
+## Precedence
+
+For settings exposed by both interfaces, the value is selected in this order:
+
+```text
+CLI option -> repository configuration -> application default
+```
+
+For example, `--min-severity high` overrides `review.minSeverity: medium`.
+
+## Security boundary
+
+Configuration is repository-defined guidance, not a system instruction. It cannot change prompt-injection protections, request secrets, execute commands, or override the review safety policy. Future configuration fields will be validated before they reach the review engine.

--- a/examples/oss-pr-reviewer.yml
+++ b/examples/oss-pr-reviewer.yml
@@ -1,0 +1,4 @@
+version: 1
+
+review:
+  minSeverity: medium

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^14.0.0",
         "dotenv": "^17.0.0",
         "openai": "^5.0.0",
+        "yaml": "^2.9.0",
         "zod": "^3.25.0"
       },
       "bin": {
@@ -3353,6 +3354,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "commander": "^14.0.0",
     "dotenv": "^17.0.0",
     "openai": "^5.0.0",
+    "yaml": "^2.9.0",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -7,6 +7,8 @@ import { parsePullRequestUrl, parseRepository } from '../../github/types.js';
 import { renderMarkdown } from '../../report/markdown.js';
 import { reviewPullRequest } from '../../review/reviewer.js';
 import type { Severity } from '../../types.js';
+import type { RepositoryConfig } from '../../config/repository.js';
+import { getConfiguredMinimumSeverity, loadRepositoryConfig } from '../../config/repository.js';
 
 export interface ReviewCommandOptions {
   repo?: string;
@@ -14,7 +16,7 @@ export interface ReviewCommandOptions {
   url?: string;
   output?: string;
   model?: string;
-  minSeverity: Severity;
+  minSeverity?: Severity;
 }
 
 export async function executeReview(options: ReviewCommandOptions): Promise<string> {
@@ -23,8 +25,17 @@ export async function executeReview(options: ReviewCommandOptions): Promise<stri
   const openAiApiKey = requireOpenAiKey(config);
   const github = new GithubClient({ token: config.githubToken });
   const pullRequest = await github.getPullRequest(input.repository, input.number);
+  const repositoryConfig = await loadRepositoryConfig(github, {
+    owner: pullRequest.owner,
+    repository: pullRequest.repository,
+    ref: pullRequest.baseSha,
+  });
   const provider = new OpenAiReviewProvider(openAiApiKey, options.model);
-  const execution = await reviewPullRequest(pullRequest, provider, options.minSeverity);
+  const execution = await reviewPullRequest(
+    pullRequest,
+    provider,
+    resolveMinimumSeverity(options.minSeverity, repositoryConfig),
+  );
   const report = renderMarkdown({ pullRequest, ...execution });
 
   if (options.output) {
@@ -38,6 +49,13 @@ export async function executeReview(options: ReviewCommandOptions): Promise<stri
   }
 
   return report;
+}
+
+export function resolveMinimumSeverity(
+  cliValue: Severity | undefined,
+  repositoryConfig: RepositoryConfig,
+): Severity {
+  return cliValue ?? getConfiguredMinimumSeverity(repositoryConfig);
 }
 
 function resolveInput(options: ReviewCommandOptions): {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,11 +23,7 @@ program
   .option('--url <url>', 'GitHub pull request URL')
   .option('--output <path>', 'write Markdown report to a file instead of only stdout')
   .option('--model <model-name>', 'OpenAI model name', 'gpt-4o-mini')
-  .option(
-    '--min-severity <severity>',
-    'minimum finding severity (low, medium, high, critical)',
-    'low',
-  )
+  .option('--min-severity <severity>', 'minimum finding severity (low, medium, high, critical)')
   .action(
     async (options: {
       repo?: string;
@@ -35,16 +31,16 @@ program
       url?: string;
       output?: string;
       model?: string;
-      minSeverity: string;
+      minSeverity?: string;
     }) => {
-      if (!severities.includes(options.minSeverity as Severity)) {
+      if (options.minSeverity && !severities.includes(options.minSeverity as Severity)) {
         throw new Error(
           `Unsupported severity '${options.minSeverity}'. Choose low, medium, high, or critical.`,
         );
       }
       const report = await executeReview({
         ...options,
-        minSeverity: options.minSeverity as Severity,
+        minSeverity: options.minSeverity as Severity | undefined,
       });
       if (!options.output) process.stdout.write(report);
     },

--- a/src/config/repository.ts
+++ b/src/config/repository.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import { parse as parseYaml } from 'yaml';
+
+import type { Severity } from '../types.js';
+import type { RepositoryReference } from '../github/types.js';
+
+const repositoryConfigSchema = z
+  .object({
+    version: z.literal(1),
+    review: z
+      .object({
+        minSeverity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+      })
+      .default({}),
+  })
+  .strict();
+
+export type RepositoryConfig = z.infer<typeof repositoryConfigSchema>;
+
+export interface RepositoryFileReader {
+  getFileAtRef(
+    reference: RepositoryReference,
+    path: string,
+    ref: string,
+  ): Promise<string | undefined>;
+}
+
+export interface TrustedConfigReference {
+  owner: string;
+  repository: string;
+  ref: string;
+}
+
+export const DEFAULT_REPOSITORY_CONFIG: RepositoryConfig = { version: 1, review: {} };
+
+export function parseRepositoryConfig(content: string): RepositoryConfig {
+  let value: unknown;
+  try {
+    value = parseYaml(content);
+  } catch (error) {
+    throw new Error(
+      `Repository configuration is invalid: ${error instanceof Error ? error.message : 'invalid YAML'}`,
+    );
+  }
+
+  const parsed = repositoryConfigSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      `Repository configuration is invalid: ${parsed.error.issues.map((issue) => `${issue.path.join('.') || 'root'} ${issue.message}`).join('; ')}`,
+    );
+  }
+  return parsed.data;
+}
+
+export async function loadRepositoryConfig(
+  reader: RepositoryFileReader,
+  reference: TrustedConfigReference,
+): Promise<RepositoryConfig> {
+  let content: string | undefined;
+  try {
+    content = await reader.getFileAtRef(
+      { owner: reference.owner, repository: reference.repository },
+      '.oss-pr-reviewer.yml',
+      reference.ref,
+    );
+  } catch (error) {
+    throw new Error(
+      `Could not load repository configuration: ${error instanceof Error ? error.message : 'GitHub API error'}`,
+    );
+  }
+
+  return content === undefined ? DEFAULT_REPOSITORY_CONFIG : parseRepositoryConfig(content);
+}
+
+export function getConfiguredMinimumSeverity(config: RepositoryConfig): Severity {
+  return config.review.minSeverity ?? 'low';
+}

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -1,14 +1,16 @@
 import { Octokit } from '@octokit/rest';
+import { Buffer } from 'node:buffer';
 
 import type { PullRequest } from '../types.js';
 import type { RepositoryReference } from './types.js';
+import type { RepositoryFileReader } from '../config/repository.js';
 
 interface GithubClientOptions {
   token?: string;
   octokit?: Octokit;
 }
 
-export class GithubClient {
+export class GithubClient implements RepositoryFileReader {
   private readonly octokit: Octokit;
 
   constructor(options: GithubClientOptions = {}) {
@@ -38,6 +40,7 @@ export class GithubClient {
         number,
         title: pullResponse.data.title,
         body: pullResponse.data.body ?? '',
+        baseSha: pullResponse.data.base.sha,
         files: filesResponse.map((file) => ({
           path: file.filename,
           status: file.status,
@@ -48,6 +51,27 @@ export class GithubClient {
         })),
       };
     } catch (error) {
+      throw normalizeGithubError(error);
+    }
+  }
+
+  async getFileAtRef(
+    reference: RepositoryReference,
+    path: string,
+    ref: string,
+  ): Promise<string | undefined> {
+    try {
+      const response = await this.octokit.repos.getContent({
+        owner: reference.owner,
+        repo: reference.repository,
+        path,
+        ref,
+      });
+      if (!('content' in response.data) || response.data.type !== 'file') return undefined;
+      return Buffer.from(response.data.content, 'base64').toString('utf8');
+    } catch (error) {
+      const candidate = error as { status?: number };
+      if (candidate.status === 404) return undefined;
       throw normalizeGithubError(error);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './review/severity.js';
 export * from './report/markdown.js';
 export * from './ai/provider.js';
 export * from './ai/client.js';
+export * from './config/repository.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface PullRequest {
   number: number;
   title: string;
   body: string;
+  baseSha: string;
   files: ChangedFile[];
 }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { loadRepositoryConfig, parseRepositoryConfig } from '../src/config/repository.js';
+import { resolveMinimumSeverity } from '../src/cli/commands/review.js';
+
+describe('repository configuration', () => {
+  it('parses a versioned minimum severity configuration', () => {
+    expect(parseRepositoryConfig('version: 1\nreview:\n  minSeverity: medium\n')).toEqual({
+      version: 1,
+      review: { minSeverity: 'medium' },
+    });
+  });
+
+  it('rejects unsupported versions and invalid severities', () => {
+    expect(() => parseRepositoryConfig('version: 2')).toThrow(/version/);
+    expect(() => parseRepositoryConfig('version: 1\nreview:\n  minSeverity: urgent')).toThrow(
+      /minSeverity/,
+    );
+  });
+
+  it('rejects unknown configuration keys', () => {
+    expect(() => parseRepositoryConfig('version: 1\nunsupported: true')).toThrow(/unsupported/);
+  });
+
+  it('uses defaults when the trusted base branch has no config file', async () => {
+    const reader = { getFileAtRef: vi.fn().mockResolvedValue(undefined) };
+    await expect(
+      loadRepositoryConfig(reader, { owner: 'octo', repository: 'project', ref: 'base-sha' }),
+    ).resolves.toEqual({ version: 1, review: {} });
+    expect(reader.getFileAtRef).toHaveBeenCalledWith(
+      { owner: 'octo', repository: 'project' },
+      '.oss-pr-reviewer.yml',
+      'base-sha',
+    );
+  });
+
+  it('loads config from the supplied trusted ref', async () => {
+    const reader = {
+      getFileAtRef: vi.fn().mockResolvedValue('version: 1\nreview:\n  minSeverity: high'),
+    };
+    await expect(
+      loadRepositoryConfig(reader, { owner: 'octo', repository: 'project', ref: 'base-sha' }),
+    ).resolves.toEqual({ version: 1, review: { minSeverity: 'high' } });
+  });
+
+  it('does not silently accept invalid trusted configuration', async () => {
+    const reader = { getFileAtRef: vi.fn().mockResolvedValue('version: 1\nreview: [invalid]') };
+    await expect(
+      loadRepositoryConfig(reader, { owner: 'octo', repository: 'project', ref: 'base-sha' }),
+    ).rejects.toThrow(/configuration/);
+  });
+
+  it('gives an explicit CLI value precedence over repository configuration', () => {
+    expect(
+      resolveMinimumSeverity('critical', { version: 1, review: { minSeverity: 'medium' } }),
+    ).toBe('critical');
+    expect(
+      resolveMinimumSeverity(undefined, { version: 1, review: { minSeverity: 'medium' } }),
+    ).toBe('medium');
+    expect(resolveMinimumSeverity(undefined, { version: 1, review: {} })).toBe('low');
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -6,6 +6,7 @@ export const pullRequestFixture: PullRequest = {
   number: 12,
   title: 'Validate account access',
   body: 'Adds an authorization check.',
+  baseSha: 'base-sha',
   files: [
     {
       path: 'src/api/account.ts',

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
 
 import { GithubClient } from '../src/github/client.js';
 import type { RepositoryReference } from '../src/github/types.js';
@@ -9,7 +10,9 @@ describe('GitHub client', () => {
   it('normalizes pull request and file API responses', async () => {
     const octokit = {
       pulls: {
-        get: vi.fn().mockResolvedValue({ data: { title: 'Title', body: null } }),
+        get: vi.fn().mockResolvedValue({
+          data: { title: 'Title', body: null, base: { sha: 'base-sha' } },
+        }),
         listFiles: vi.fn(),
       },
       paginate: vi.fn().mockResolvedValue([
@@ -51,5 +54,39 @@ describe('GitHub client', () => {
         new GithubClient({ octokit: octokit as never }).getPullRequest(reference, 4),
       ).rejects.toThrow(message);
     }
+  });
+
+  it('reads and decodes a file from a trusted ref', async () => {
+    const octokit = {
+      repos: {
+        getContent: vi.fn().mockResolvedValue({
+          data: { type: 'file', content: Buffer.from('version: 1').toString('base64') },
+        }),
+      },
+    };
+    await expect(
+      new GithubClient({ octokit: octokit as never }).getFileAtRef(
+        reference,
+        '.oss-pr-reviewer.yml',
+        'base-sha',
+      ),
+    ).resolves.toBe('version: 1');
+    expect(octokit.repos.getContent).toHaveBeenCalledWith({
+      owner: 'octo',
+      repo: 'project',
+      path: '.oss-pr-reviewer.yml',
+      ref: 'base-sha',
+    });
+  });
+
+  it('treats a missing config file as absent', async () => {
+    const octokit = { repos: { getContent: vi.fn().mockRejectedValue({ status: 404 }) } };
+    await expect(
+      new GithubClient({ octokit: octokit as never }).getFileAtRef(
+        reference,
+        '.oss-pr-reviewer.yml',
+        'base-sha',
+      ),
+    ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds the first v0.2 configuration capability while preserving v0.1 behavior when no config file exists.

## Changes

- Add versioned `.oss-pr-reviewer.yml` parsing and Zod validation.
- Load configuration from the pull request base SHA through the GitHub contents API.
- Add CLI-over-config-over-default minimum severity precedence.
- Add configuration docs and a safe example.
- Add deterministic tests for missing, valid, invalid, unsupported, and trusted-ref configuration.

## Security

The PR head cannot activate its own review policy. Configuration is read from the trusted base commit and remains repository guidance, not system instructions.

## Testing

- lint
- typecheck
- 36 tests across 7 suites
- build
- format:check
- mocked GitHub contents behavior

Live GitHub/OpenAI smoke testing is not included and is not required for CI.
