### PR TITLE
refactor: introduce explicit review context budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Run lint, typecheck, tests, and build in GitHub Actions without secrets.
 - Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 - Add repository-specific review rules and ignore paths without changing application code.
+- Reserve predictable prompt/response space with simple character-based context budget settings.
 
 ## How It Works
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,8 @@ PR normalization
   |
 Path ignores
   |
+Context budget
+  |
 Deterministic batching
   |
 Review engine
@@ -33,7 +35,8 @@ Markdown renderer
 - `src/config/repository.ts` validates optional `.oss-pr-reviewer.yml` content loaded from the pull request base SHA. PR-head configuration is never used as active policy.
 - `src/review/ignore.ts` applies repository glob exclusions before normalization. Ignored files remain visible in skipped-file reporting.
 - `src/review/normalize.ts` removes binary and patchless files from AI input while preserving skip reasons for the report.
-- `src/review/batching.ts` applies the centralized `maxDiffSize`, `maxFileSize`, and `maxFilesPerBatch` limits.
+- `src/review/batching.ts` applies centralized diff, file, batch, and reserved-context limits through `ReviewBudget`.
+- `src/review/batching.ts` exposes an explicit character-based budget with reserved prompt/response space while retaining the v0.1 legacy batching shape.
 - `src/ai/` contains the OpenAI SDK boundary. The rest of the review engine depends on the small `ReviewProvider` interface.
 - `src/review/schema.ts` validates every provider response before it enters the merge pipeline.
 - `src/report/` renders the final report without making claims that automated review is definitive.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,10 @@ ignore:
   paths:
     - docs/**
     - '**/*.generated.ts'
+
+context:
+  maxFilesPerBatch: 10
+  reservedResponseCharacters: 15000
 ```
 
 The currently supported settings are:
@@ -26,6 +30,7 @@ The currently supported settings are:
 - `review.minSeverity`: optional `low`, `medium`, `high`, or `critical` value.
 - `rules`: optional list of stable kebab-case `id` values and non-empty review `description` text.
 - `ignore.paths`: optional list of validated glob patterns. Matching files are not sent to the AI provider and are reported as ignored.
+- `context`: optional numeric context-budget overrides. Supported values are `maxFilesPerBatch`, `maxDiffCharacters`, `maxFileCharacters`, `reservedPromptCharacters`, and `reservedResponseCharacters`.
 
 If the file is absent, v0.1 behavior is preserved and the default minimum severity is `low`. Invalid YAML, unsupported keys, unsupported versions, or invalid values fail the review with an actionable configuration error; they are not silently ignored.
 
@@ -44,3 +49,5 @@ For example, `--min-severity high` overrides `review.minSeverity: medium`.
 Configuration is repository-defined guidance, not a system instruction. It cannot change prompt-injection protections, request secrets, execute commands, or override the review safety policy. Future configuration fields will be validated before they reach the review engine.
 
 Custom rule descriptions are inserted into a clearly labeled untrusted guidance section in the review request. Path ignores are applied before unsupported-file normalization and batching.
+
+The context budget is character-based rather than tokenizer-based. The usable diff budget is the configured maximum diff size minus reserved prompt and response characters. Files exceeding file or usable-diff limits are skipped with a reason; no token usage is fabricated.

--- a/examples/oss-pr-reviewer.yml
+++ b/examples/oss-pr-reviewer.yml
@@ -14,3 +14,6 @@ ignore:
     - docs/**
     - dist/**
     - '**/*.generated.ts'
+
+context:
+  maxFilesPerBatch: 10

--- a/src/config/repository.ts
+++ b/src/config/repository.ts
@@ -4,6 +4,7 @@ import picomatch from 'picomatch';
 
 import type { Severity } from '../types.js';
 import type { RepositoryReference } from '../github/types.js';
+import type { ReviewBudget } from '../review/batching.js';
 
 const repositoryConfigSchema = z
   .object({
@@ -31,6 +32,15 @@ const repositoryConfigSchema = z
           .default([]),
       })
       .default({}),
+    context: z
+      .object({
+        maxFilesPerBatch: z.number().int().positive().max(100).optional(),
+        maxDiffCharacters: z.number().int().positive().max(500_000).optional(),
+        maxFileCharacters: z.number().int().positive().max(200_000).optional(),
+        reservedPromptCharacters: z.number().int().nonnegative().max(100_000).optional(),
+        reservedResponseCharacters: z.number().int().nonnegative().max(100_000).optional(),
+      })
+      .default({}),
   })
   .strict();
 
@@ -56,6 +66,7 @@ export const DEFAULT_REPOSITORY_CONFIG: RepositoryConfig = {
   review: {},
   rules: [],
   ignore: { paths: [] },
+  context: {},
 };
 
 export function parseRepositoryConfig(content: string): RepositoryConfig {
@@ -99,6 +110,13 @@ export async function loadRepositoryConfig(
 
 export function getConfiguredMinimumSeverity(config: RepositoryConfig): Severity {
   return config.review.minSeverity ?? 'low';
+}
+
+export function getConfiguredReviewBudget(
+  config: RepositoryConfig,
+  defaults: ReviewBudget,
+): ReviewBudget {
+  return { ...defaults, ...config.context };
 }
 
 function isValidGlob(pattern: string): boolean {

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -32,7 +32,10 @@ ${findings}
 ## Review Statistics
 
 - Files reviewed: ${data.reviewedFileCount}
+- Files changed: ${data.changedFileCount}
+- Files ignored: ${data.ignoredFileCount}
 - Files skipped: ${skippedFiles.length}
+- Review batches: ${data.batchCount}
 - Findings: ${result.findings.length}
 - Critical: ${counts.critical}
 - High: ${counts.high}

--- a/src/review/batching.ts
+++ b/src/review/batching.ts
@@ -1,9 +1,25 @@
 import type { ReviewableFile, SkippedFile } from '../types.js';
 
-export const REVIEW_LIMITS = {
-  maxDiffSize: 60_000,
-  maxFileSize: 30_000,
+export interface ReviewBudget {
+  maxDiffCharacters: number;
+  maxFileCharacters: number;
+  maxFilesPerBatch: number;
+  reservedPromptCharacters: number;
+  reservedResponseCharacters: number;
+}
+
+export const DEFAULT_REVIEW_BUDGET: ReviewBudget = {
+  maxDiffCharacters: 60_000,
+  maxFileCharacters: 30_000,
   maxFilesPerBatch: 8,
+  reservedPromptCharacters: 8_000,
+  reservedResponseCharacters: 12_000,
+} as const;
+
+export const REVIEW_LIMITS = {
+  maxDiffSize: DEFAULT_REVIEW_BUDGET.maxDiffCharacters,
+  maxFileSize: DEFAULT_REVIEW_BUDGET.maxFileCharacters,
+  maxFilesPerBatch: DEFAULT_REVIEW_BUDGET.maxFilesPerBatch,
 } as const;
 
 export interface ReviewBatch {
@@ -11,30 +27,61 @@ export interface ReviewBatch {
   characterCount: number;
 }
 
+export function budgetFromLegacyLimits(limits: typeof REVIEW_LIMITS): ReviewBudget {
+  return {
+    maxDiffCharacters: limits.maxDiffSize,
+    maxFileCharacters: limits.maxFileSize,
+    maxFilesPerBatch: limits.maxFilesPerBatch,
+    reservedPromptCharacters: 0,
+    reservedResponseCharacters: 0,
+  };
+}
+
+export function getUsableDiffCharacters(budget: ReviewBudget): number {
+  const usable =
+    budget.maxDiffCharacters - budget.reservedPromptCharacters - budget.reservedResponseCharacters;
+  if (usable <= 0) throw new Error('Review budget must reserve less context than its maximum.');
+  return usable;
+}
+
 export function createBatches(
   files: ReviewableFile[],
-  limits: typeof REVIEW_LIMITS = REVIEW_LIMITS,
+  limits: ReviewBudget | typeof REVIEW_LIMITS = DEFAULT_REVIEW_BUDGET,
 ): { batches: ReviewBatch[]; skipped: SkippedFile[] } {
+  const budget =
+    'maxDiffCharacters' in limits
+      ? limits
+      : {
+          maxDiffCharacters: limits.maxDiffSize,
+          maxFileCharacters: limits.maxFileSize,
+          maxFilesPerBatch: limits.maxFilesPerBatch,
+          reservedPromptCharacters: 0,
+          reservedResponseCharacters: 0,
+        };
+  const maxDiffCharacters = getUsableDiffCharacters(budget);
   const batches: ReviewBatch[] = [];
   const skipped: SkippedFile[] = [];
   let current: ReviewBatch = { files: [], characterCount: 0 };
 
   for (const file of files) {
-    if (file.patch.length > limits.maxFileSize) {
-      skipped.push({ path: file.path, reason: `patch exceeds ${limits.maxFileSize} characters` });
-      continue;
-    }
-
-    if (file.patch.length > limits.maxDiffSize) {
+    if (file.patch.length > budget.maxFileCharacters) {
       skipped.push({
         path: file.path,
-        reason: `patch exceeds ${limits.maxDiffSize} character batch limit`,
+        reason: `patch exceeds ${budget.maxFileCharacters} characters`,
       });
       continue;
     }
 
-    const wouldExceedSize = current.characterCount + file.patch.length > limits.maxDiffSize;
-    const wouldExceedFiles = current.files.length >= limits.maxFilesPerBatch;
+    if (file.patch.length > maxDiffCharacters) {
+      skipped.push({
+        path: file.path,
+        reason: `patch exceeds ${maxDiffCharacters} character batch limit`,
+      });
+      continue;
+    }
+
+    const wouldExceedSize = current.characterCount + file.patch.length > maxDiffCharacters;
+    const wouldExceedFiles = current.files.length >= budget.maxFilesPerBatch;
     if (current.files.length > 0 && (wouldExceedSize || wouldExceedFiles)) {
       batches.push(current);
       current = { files: [], characterCount: 0 };

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -1,7 +1,7 @@
 import type { PullRequest, ReviewResult, Severity, SkippedFile } from '../types.js';
 import type { RepositoryConfig } from '../config/repository.js';
-import { DEFAULT_REPOSITORY_CONFIG } from '../config/repository.js';
-import { createBatches } from './batching.js';
+import { DEFAULT_REPOSITORY_CONFIG, getConfiguredReviewBudget } from '../config/repository.js';
+import { createBatches, DEFAULT_REVIEW_BUDGET } from './batching.js';
 import { filterIgnoredFiles } from './ignore.js';
 import { normalizeFiles } from './normalize.js';
 import { deduplicateFindings, filterFindings, severityOrder } from './severity.js';
@@ -11,6 +11,9 @@ export interface ReviewExecution {
   result: ReviewResult;
   skippedFiles: SkippedFile[];
   reviewedFileCount: number;
+  changedFileCount: number;
+  ignoredFileCount: number;
+  batchCount: number;
 }
 
 export async function reviewPullRequest(
@@ -21,7 +24,10 @@ export async function reviewPullRequest(
 ): Promise<ReviewExecution> {
   const ignored = filterIgnoredFiles(pullRequest.files, repositoryConfig.ignore.paths);
   const normalized = normalizeFiles(ignored.files);
-  const batched = createBatches(normalized.reviewable);
+  const batched = createBatches(
+    normalized.reviewable,
+    getConfiguredReviewBudget(repositoryConfig, DEFAULT_REVIEW_BUDGET),
+  );
   const skippedFiles = [...ignored.skipped, ...normalized.skipped, ...batched.skipped];
 
   if (batched.batches.length === 0) {
@@ -33,6 +39,9 @@ export async function reviewPullRequest(
       },
       skippedFiles,
       reviewedFileCount: 0,
+      changedFileCount: pullRequest.files.length,
+      ignoredFileCount: ignored.skipped.length,
+      batchCount: 0,
     };
   }
 
@@ -59,5 +68,8 @@ export async function reviewPullRequest(
     result: { summary, riskLevel, findings },
     skippedFiles,
     reviewedFileCount: normalized.reviewable.length - batched.skipped.length,
+    changedFileCount: pullRequest.files.length,
+    ignoredFileCount: ignored.skipped.length,
+    batchCount: batched.batches.length,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,4 +70,7 @@ export interface ReviewReportData {
   result: ReviewResult;
   skippedFiles: SkippedFile[];
   reviewedFileCount: number;
+  changedFileCount: number;
+  ignoredFileCount: number;
+  batchCount: number;
 }

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createBatches,
+  DEFAULT_REVIEW_BUDGET,
+  getUsableDiffCharacters,
+} from '../src/review/batching.js';
+
+describe('review context budgeting', () => {
+  it('reserves prompt and response space from the diff budget', () => {
+    expect(
+      getUsableDiffCharacters({
+        maxDiffCharacters: 100,
+        maxFileCharacters: 80,
+        maxFilesPerBatch: 4,
+        reservedPromptCharacters: 20,
+        reservedResponseCharacters: 30,
+      }),
+    ).toBe(50);
+  });
+
+  it('uses a deterministic default budget', () => {
+    expect(DEFAULT_REVIEW_BUDGET).toEqual({
+      maxDiffCharacters: 60_000,
+      maxFileCharacters: 30_000,
+      maxFilesPerBatch: 8,
+      reservedPromptCharacters: 8_000,
+      reservedResponseCharacters: 12_000,
+    });
+    expect(getUsableDiffCharacters(DEFAULT_REVIEW_BUDGET)).toBe(40_000);
+  });
+
+  it('packs files against the usable diff budget and reports batch count', () => {
+    const result = createBatches(
+      [
+        { path: 'a.ts', status: 'modified', additions: 1, deletions: 0, patch: 'a'.repeat(20) },
+        { path: 'b.ts', status: 'modified', additions: 1, deletions: 0, patch: 'b'.repeat(20) },
+        { path: 'c.ts', status: 'modified', additions: 1, deletions: 0, patch: 'c'.repeat(20) },
+      ],
+      {
+        maxDiffCharacters: 70,
+        maxFileCharacters: 30,
+        maxFilesPerBatch: 8,
+        reservedPromptCharacters: 10,
+        reservedResponseCharacters: 10,
+      },
+    );
+    expect(result.batches.map((batch) => batch.files.map((file) => file.path))).toEqual([
+      ['a.ts', 'b.ts'],
+      ['c.ts'],
+    ]);
+  });
+
+  it('rejects budgets whose reserved context exceeds the maximum', () => {
+    expect(() =>
+      getUsableDiffCharacters({
+        maxDiffCharacters: 10,
+        maxFileCharacters: 10,
+        maxFilesPerBatch: 1,
+        reservedPromptCharacters: 6,
+        reservedResponseCharacters: 5,
+      }),
+    ).toThrow(/budget/);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -14,6 +14,7 @@ describe('repository configuration', () => {
       review: { minSeverity: 'medium' },
       rules: [{ id: 'require-tests', description: 'Changes need tests.' }],
       ignore: { paths: ['docs/**'] },
+      context: {},
     });
   });
 
@@ -39,7 +40,7 @@ describe('repository configuration', () => {
     const reader = { getFileAtRef: vi.fn().mockResolvedValue(undefined) };
     await expect(
       loadRepositoryConfig(reader, { owner: 'octo', repository: 'project', ref: 'base-sha' }),
-    ).resolves.toEqual({ version: 1, review: {}, rules: [], ignore: { paths: [] } });
+    ).resolves.toEqual({ version: 1, review: {}, rules: [], ignore: { paths: [] }, context: {} });
     expect(reader.getFileAtRef).toHaveBeenCalledWith(
       { owner: 'octo', repository: 'project' },
       '.oss-pr-reviewer.yml',
@@ -58,6 +59,7 @@ describe('repository configuration', () => {
       review: { minSeverity: 'high' },
       rules: [],
       ignore: { paths: [] },
+      context: {},
     });
   });
 
@@ -76,5 +78,12 @@ describe('repository configuration', () => {
       resolveMinimumSeverity(undefined, { version: 1, review: { minSeverity: 'medium' } }),
     ).toBe('medium');
     expect(resolveMinimumSeverity(undefined, { version: 1, review: {} })).toBe('low');
+  });
+
+  it('validates and exposes context budget overrides', () => {
+    const config = parseRepositoryConfig(
+      'version: 1\ncontext:\n  maxFilesPerBatch: 10\n  reservedResponseCharacters: 15000',
+    );
+    expect(config.context).toEqual({ maxFilesPerBatch: 10, reservedResponseCharacters: 15000 });
   });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -10,9 +10,14 @@ describe('Markdown report', () => {
       result: resultFixture({ findings: [], riskLevel: 'low' }),
       skippedFiles: [],
       reviewedFileCount: 2,
+      changedFileCount: 2,
+      ignoredFileCount: 0,
+      batchCount: 1,
     });
     expect(report).toContain('No significant issues');
     expect(report).toContain('Files reviewed: 2');
+    expect(report).toContain('Files changed: 2');
+    expect(report).toContain('Review batches: 1');
     expect(report).toContain('does not replace human review');
   });
   it('renders finding details and skipped files', () => {
@@ -23,10 +28,14 @@ describe('Markdown report', () => {
       }),
       skippedFiles: [{ path: 'logo.png', reason: 'binary' }],
       reviewedFileCount: 1,
+      changedFileCount: 2,
+      ignoredFileCount: 0,
+      batchCount: 1,
     });
     expect(report).toContain('HIGH - Security');
     expect(report).toContain('Line: 11');
     expect(report).toContain('`logo.png`: binary');
     expect(report).toContain('Medium: 1');
+    expect(report).toContain('Files ignored: 0');
   });
 });

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -82,6 +82,9 @@ describe('review pipeline', () => {
     expect(execution.result.findings).toHaveLength(1);
     expect(execution.skippedFiles).toHaveLength(2);
     expect(execution.reviewedFileCount).toBe(1);
+    expect(execution.changedFileCount).toBe(3);
+    expect(execution.ignoredFileCount).toBe(0);
+    expect(execution.batchCount).toBe(1);
   });
   it('returns a useful empty result when no patches are reviewable', async () => {
     const provider: ReviewProvider = { review: async () => resultFixture() };
@@ -95,6 +98,8 @@ describe('review pipeline', () => {
     expect(execution.result.findings).toEqual([]);
     expect(execution.result.summary).toContain('No reviewable');
     expect(execution.reviewedFileCount).toBe(0);
+    expect(execution.changedFileCount).toBe(1);
+    expect(execution.batchCount).toBe(0);
   });
 
   it('passes repository rules to the provider and reports ignored files', async () => {


### PR DESCRIPTION
## Summary

Makes review context management explicit and improves report statistics while preserving the v0.1 batching compatibility shape.

## Changes

- Add `ReviewBudget` with reserved prompt/response character space.
- Keep legacy `REVIEW_LIMITS` callers working without reserved-context semantics.
- Apply configured budget values from repository configuration.
- Report changed files, ignored files, skipped files, and batch count.
- Add deterministic budget, regression, statistics, and documentation coverage.

## Testing

- lint
- typecheck
- 46 tests across 9 suites
- build
- format:check
- CLI and report behavior covered by existing tests

## Limitations

Budgeting uses a documented character approximation rather than exact model tokenization. Live GitHub/OpenAI testing remains pending.
