### PR TITLE
docs: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0
+
+- Added optional trusted-base `.oss-pr-reviewer.yml` configuration with validated CLI precedence.
+- Added repository custom review rules and validated glob-based ignored paths.
+- Added explicit character-based context budgeting with reserved prompt/response space.
+- Added changed, ignored, skipped, and batch counts to Markdown review statistics.
+- Added configuration documentation and examples.
+
+Live GitHub/OpenAI smoke testing remains pending; automated validation uses deterministic mocks and fixtures.
+
 ## 0.1.0
 
 - Added a TypeScript CLI for reviewing GitHub pull requests by repository/PR or URL.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,6 @@ npm run format:check
 
 Add deterministic unit coverage for new behavior. Do not make tests call GitHub or OpenAI. Update README and the relevant `docs/` page when public behavior changes.
 
-When changing repository configuration, preserve the trusted-base-commit boundary and add tests for invalid input and CLI precedence.
+When changing repository configuration, preserve the trusted-base-commit boundary and add tests for invalid input, CLI precedence, rules, ignored paths, and budget behavior.
 
 Pull requests should explain the behavior change, test evidence, security implications, and known limitations. Keep changes small and reviewable.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install
 npm run build
 ```
 
-The v0.1.0 release is package-ready but is not published to npm by this repository yet. Run the CLI from the checkout with `node dist/cli/index.js`, or use `npm link` for a local global command:
+The v0.2.0 release is package-ready but is not published to npm by this repository yet. Run the CLI from the checkout with `node dist/cli/index.js`, or use `npm link` for a local global command:
 
 ```bash
 npm link
@@ -143,7 +143,7 @@ The full report also includes pull request metadata, summary, statistics, skippe
 
 ## Architecture
 
-The CLI depends on a small `ReviewProvider` interface, so the review engine does not contain OpenAI SDK details. v0.1.0 ships one provider: OpenAI. Review content is treated as untrusted data, and changed code is never executed. See [docs/architecture.md](docs/architecture.md).
+The CLI depends on a small `ReviewProvider` interface, so the review engine does not contain OpenAI SDK details. v0.2.0 ships one provider: OpenAI. Review content, repository rules, and ignored-path configuration are treated as untrusted repository data; changed code is never executed. See [docs/architecture.md](docs/architecture.md).
 
 ## Review Philosophy
 
@@ -155,9 +155,10 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 
 ## Limitations
 
-- Only OpenAI is implemented in v0.1.0.
+- Only OpenAI is implemented in v0.2.0.
 - The tool reviews supplied pull request metadata and patches rather than the full repository.
-- GitHub-truncated, missing, generated, binary, deleted, or oversized content can be skipped or reduce review context.
+- GitHub-truncated, missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
+- Context budgeting uses character approximations rather than exact model tokenization.
 - It does not post comments, create annotations, clone repositories, run tests, or replace human/security review.
 - Live API usage requires network access and valid credentials; automated tests use mocks.
 
@@ -175,10 +176,9 @@ Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md). CI runs the same
 
 ## Roadmap
 
-These are possible future directions, not v0.1.0 features:
+These are possible future directions, not v0.2.0 features:
 
-- **v0.2:** repository configuration, custom review rules, improved context/token estimation, and additional provider support.
-- **v0.3:** a GitHub Action, automatic PR comments, inline annotations, and repository-level configuration.
+- **v0.3:** a GitHub Action, automatic PR comments, inline annotations, and richer maintainer integrations.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-`oss-pr-reviewer` is a single-process CLI. It fetches only the requested pull request and changed-file patches; it does not clone or execute the repository.
+`oss-pr-reviewer` is a single-process CLI. It fetches only the requested pull request, trusted-base configuration, and changed-file patches; it does not clone or execute the repository.
 
 ```text
 CLI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Repository Configuration
 
-v0.2 supports an optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes.
+v0.2.0 supports an optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes.
 
 ## Example
 

--- a/docs/review-format.md
+++ b/docs/review-format.md
@@ -1,6 +1,6 @@
 # Review Format
 
-The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer.
+The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. v0.2.0 statistics also include files changed, files ignored by configuration, and review batches.
 
 ## Severity
 
@@ -23,4 +23,4 @@ Each finding includes a title, file, optional line, evidence-based explanation, 
 
 ## Interpretation
 
-Read findings as maintainer leads for further investigation. The model sees the pull request metadata and reviewable patches only. Missing context, truncated patches, generated files, binary files, and deleted files can limit accuracy. Automated output does not replace human review, testing, or a security audit.
+Read findings as maintainer leads for further investigation. The model sees the pull request metadata, trusted-base repository guidance, and reviewable patches only. Missing context, truncated patches, generated files, binary files, deleted files, ignored files, and oversized content can limit accuracy. Automated output does not replace human review, testing, or a security audit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-pr-reviewer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-pr-reviewer",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-pr-reviewer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI-powered CLI for reviewing GitHub pull requests, detecting potential bugs, security risks, regressions, and missing tests, with structured Markdown reports for open-source maintainers.",
   "type": "module",
   "bin": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,7 @@ const program = new Command()
   .description(
     'AI-powered CLI for reviewing GitHub pull requests with structured Markdown reports.',
   )
-  .version('0.1.0');
+  .version('0.2.0');
 
 program
   .command('review')

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import process from 'node:process';
+import { readFile } from 'node:fs/promises';
+import { URL } from 'node:url';
 
 import { parsePullRequestUrl, parseRepository } from '../src/github/types.js';
 import { executeReview } from '../src/cli/commands/review.js';
 
 describe('CLI input parsing', () => {
+  it('keeps the CLI version aligned with release metadata', async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as { version: string };
+    expect(packageJson.version).toBe('0.2.0');
+  });
   it('parses owner/repository', () =>
     expect(parseRepository('octo/project')).toEqual({ owner: 'octo', repository: 'project' }));
   it('rejects malformed repositories', () =>


### PR DESCRIPTION
## Summary

Prepares the public project metadata and documentation for the v0.2.0 release.

## Changes

- Set package, lockfile, and CLI version to 0.2.0.
- Document trusted repository configuration, custom rules, ignored paths, and context budgeting.
- Update changelog, roadmap, limitations, architecture, review format, and contribution guidance.
- Add a version metadata regression test.

## Testing

- lint
- typecheck
- 47 tests across 9 suites
- build
- format:check
- CLI version and help
- package dry-run

## Security

Documentation preserves the trusted base-commit configuration boundary and untrusted custom-rule guidance. No credentials or live API claims are included.

Live GitHub/OpenAI smoke testing remains pending.
