### PR TITLE
feat: add GitHub Action review foundation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,33 @@
+name: oss-pr-reviewer
+description: Run an advisory AI review for a pull_request and append the Markdown report to the job summary.
+author: oss-pr-reviewer maintainers
+inputs:
+  github-token:
+    description: GitHub token used to read pull request metadata and patches.
+    required: true
+  openai-api-key:
+    description: OpenAI API key used for the review request.
+    required: true
+  model:
+    description: OpenAI model name.
+    required: false
+    default: gpt-4o-mini
+  min-severity:
+    description: Minimum finding severity to include in the report.
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Build and run oss-pr-reviewer
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        ACTION_MODEL: ${{ inputs.model }}
+        ACTION_MIN_SEVERITY: ${{ inputs.min-severity }}
+      run: |
+        set -euo pipefail
+        npm ci --ignore-scripts --prefix "$ACTION_PATH"
+        npm run build --prefix "$ACTION_PATH"
+        node "$ACTION_PATH/dist/action/main.js"

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -1,0 +1,31 @@
+import { parsePullRequestUrl } from '../github/types.js';
+
+const supportedActions = new Set(['opened', 'synchronize', 'reopened']);
+
+export interface PullRequestEvent {
+  url: string;
+  number: number;
+}
+
+export function parsePullRequestEvent(value: unknown): PullRequestEvent {
+  if (!value || typeof value !== 'object') {
+    throw new Error('GitHub event is missing pull_request metadata.');
+  }
+
+  const event = value as {
+    action?: unknown;
+    pull_request?: { number?: unknown; html_url?: unknown };
+  };
+  if (typeof event.action !== 'string' || !supportedActions.has(event.action)) {
+    throw new Error('This Action supports only opened, synchronize, or reopened pull requests.');
+  }
+  if (!event.pull_request || typeof event.pull_request.html_url !== 'string') {
+    throw new Error('GitHub event is missing pull_request metadata.');
+  }
+
+  const parsed = parsePullRequestUrl(event.pull_request.html_url);
+  if (event.pull_request.number !== undefined && event.pull_request.number !== parsed.number) {
+    throw new Error('GitHub event pull request number does not match its URL.');
+  }
+  return { url: event.pull_request.html_url, number: parsed.number };
+}

--- a/src/action/inputs.ts
+++ b/src/action/inputs.ts
@@ -1,0 +1,58 @@
+import type { Severity } from '../types.js';
+import type { ReviewCommandOptions } from '../cli/commands/review.js';
+import type { PullRequestEvent } from './event.js';
+
+const severities: Severity[] = ['low', 'medium', 'high', 'critical'];
+
+export interface ActionInputs {
+  githubToken: string;
+  openAiApiKey: string;
+  model?: string;
+  minSeverity?: Severity;
+}
+
+export interface ActionEnvironment {
+  GITHUB_TOKEN?: string;
+  OPENAI_API_KEY?: string;
+  ACTION_MODEL?: string;
+  ACTION_MIN_SEVERITY?: string;
+}
+
+export function parseActionInputs(environment: ActionEnvironment): ActionInputs {
+  const githubToken = environment.GITHUB_TOKEN?.trim();
+  const openAiApiKey = environment.OPENAI_API_KEY?.trim();
+  if (!githubToken) throw new Error('GITHUB_TOKEN is required for the GitHub Action.');
+  if (!openAiApiKey) throw new Error('OPENAI_API_KEY is required for the GitHub Action.');
+
+  const model = environment.ACTION_MODEL?.trim() || undefined;
+  const rawSeverity = environment.ACTION_MIN_SEVERITY?.trim() || undefined;
+  if (rawSeverity && !severities.includes(rawSeverity as Severity)) {
+    throw new Error(
+      `Unsupported Action severity '${rawSeverity}'. Choose low, medium, high, or critical.`,
+    );
+  }
+
+  return {
+    githubToken,
+    openAiApiKey,
+    model,
+    minSeverity: rawSeverity as Severity | undefined,
+  };
+}
+
+export function buildActionReviewOptions(
+  event: PullRequestEvent,
+  inputs: Pick<ActionInputs, 'model' | 'minSeverity'>,
+): ReviewCommandOptions {
+  return {
+    url: event.url,
+    model: inputs.model,
+    minSeverity: inputs.minSeverity,
+  };
+}
+
+export function redactSecrets(value: string, secrets: string[]): string {
+  return secrets
+    .filter(Boolean)
+    .reduce((redacted, secret) => redacted.split(secret).join('[REDACTED]'), value);
+}

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import process from 'node:process';
+
+import { executeReview } from '../cli/commands/review.js';
+import { parsePullRequestEvent } from './event.js';
+import { buildActionReviewOptions, parseActionInputs, redactSecrets } from './inputs.js';
+import { writeActionReport } from './output.js';
+
+async function main(): Promise<void> {
+  const inputs = parseActionInputs({
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    ACTION_MODEL: process.env.ACTION_MODEL,
+    ACTION_MIN_SEVERITY: process.env.ACTION_MIN_SEVERITY,
+  });
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is required for the GitHub Action.');
+  const event = parsePullRequestEvent(JSON.parse(await readFile(eventPath, 'utf8')));
+
+  process.env.GITHUB_TOKEN = inputs.githubToken;
+  process.env.OPENAI_API_KEY = inputs.openAiApiKey;
+  const report = await executeReview(buildActionReviewOptions(event, inputs));
+  const reportPath = join(process.env.RUNNER_TEMP ?? process.cwd(), 'oss-pr-reviewer-report.md');
+  await writeActionReport(report, reportPath, process.env.GITHUB_STEP_SUMMARY);
+}
+
+try {
+  await main();
+} catch (error) {
+  const secrets = [process.env.GITHUB_TOKEN ?? '', process.env.OPENAI_API_KEY ?? ''];
+  process.stderr.write(
+    `${redactSecrets(error instanceof Error ? error.message : 'Unexpected GitHub Action error.', secrets)}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/src/action/output.ts
+++ b/src/action/output.ts
@@ -1,0 +1,10 @@
+import { appendFile, writeFile } from 'node:fs/promises';
+
+export async function writeActionReport(
+  report: string,
+  reportPath: string,
+  summaryPath?: string,
+): Promise<void> {
+  await writeFile(reportPath, report, 'utf8');
+  if (summaryPath) await appendFile(summaryPath, `${report.trimEnd()}\n`, 'utf8');
+}

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildActionReviewOptions,
+  parseActionInputs,
+  redactSecrets,
+} from '../src/action/inputs.js';
+import { parsePullRequestEvent } from '../src/action/event.js';
+import { writeActionReport } from '../src/action/output.js';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('GitHub Action inputs', () => {
+  it('parses required credentials and optional review settings', () => {
+    expect(
+      parseActionInputs({
+        GITHUB_TOKEN: 'github-token',
+        OPENAI_API_KEY: 'openai-key',
+        ACTION_MODEL: 'gpt-test',
+        ACTION_MIN_SEVERITY: 'high',
+      }),
+    ).toEqual({
+      githubToken: 'github-token',
+      openAiApiKey: 'openai-key',
+      model: 'gpt-test',
+      minSeverity: 'high',
+    });
+  });
+
+  it('rejects missing credentials and unsupported severity', () => {
+    expect(() => parseActionInputs({ OPENAI_API_KEY: 'openai-key' })).toThrow(/GITHUB_TOKEN/);
+    expect(() =>
+      parseActionInputs({
+        GITHUB_TOKEN: 'github-token',
+        OPENAI_API_KEY: 'openai-key',
+        ACTION_MIN_SEVERITY: 'urgent',
+      }),
+    ).toThrow(/severity/);
+  });
+
+  it('maps action inputs to the existing review command contract', () => {
+    expect(
+      buildActionReviewOptions(
+        { url: 'https://github.com/octo/project/pull/12' },
+        { githubToken: 'github-token', openAiApiKey: 'openai-key', minSeverity: 'medium' },
+      ),
+    ).toEqual({
+      url: 'https://github.com/octo/project/pull/12',
+      minSeverity: 'medium',
+    });
+  });
+
+  it('redacts action secrets from generated output and errors', () => {
+    expect(redactSecrets('token=github-token key=openai-key', ['github-token', 'openai-key'])).toBe(
+      'token=[REDACTED] key=[REDACTED]',
+    );
+  });
+});
+
+describe('GitHub pull request event', () => {
+  it('extracts supported pull request metadata', () => {
+    expect(
+      parsePullRequestEvent({
+        action: 'synchronize',
+        pull_request: {
+          number: 12,
+          html_url: 'https://github.com/octo/project/pull/12',
+        },
+      }),
+    ).toEqual({
+      url: 'https://github.com/octo/project/pull/12',
+      number: 12,
+    });
+  });
+
+  it('rejects unsupported actions and missing pull request metadata', () => {
+    expect(() =>
+      parsePullRequestEvent({
+        action: 'closed',
+        pull_request: { number: 12, html_url: 'https://github.com/octo/project/pull/12' },
+      }),
+    ).toThrow(/opened, synchronize, or reopened/);
+    expect(() => parsePullRequestEvent({ action: 'opened' })).toThrow(/pull_request/);
+  });
+});
+
+describe('GitHub Action report output', () => {
+  it('writes the report and appends the same Markdown to the job summary', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'oss-pr-reviewer-action-'));
+    const reportPath = join(directory, 'report.md');
+    const summaryPath = join(directory, 'summary.md');
+
+    await writeActionReport('# Report\n', reportPath, summaryPath);
+
+    await expect(readFile(reportPath, 'utf8')).resolves.toBe('# Report\n');
+    await expect(readFile(summaryPath, 'utf8')).resolves.toBe('# Report\n');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable composite GitHub Action entry point for advisory pull request reviews.
- Reuse the existing CLI and review pipeline instead of duplicating review logic.
- Append the generated Markdown report to `GITHUB_STEP_SUMMARY`.

## Architecture
The composite Action builds the trusted Action checkout with `npm ci --ignore-scripts` and `npm run build`, then runs `dist/action/main.js`. The TypeScript boundary parses supported pull request event metadata, validates Action inputs, invokes the existing CLI contract, writes the report, and appends it to the job summary.

## Testing
- `npm install`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 54 tests
- `npm run build`
- `npm run format:check`
- YAML parse check for `action.yml`
- `git diff --check`

## Security
- The Action does not checkout or execute the reviewed pull request.
- The Action uses the existing GitHub/OpenAI boundaries and keeps review findings advisory.
- Secrets are passed through environment variables and redacted from Action errors.
- Default usage is intended to use least-privilege read permissions; fork secret limitations will be documented in the follow-up security PR.

## Limitations
- This PR provides summary-only output; it does not post pull request comments.
- Live GitHub/OpenAI Action testing remains pending because credentials are not used in CI.
