### PR TITLE
feat: document GitHub Action security boundaries

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,5 +15,8 @@ Only the latest release line is actively supported. Security fixes may be backpo
 - Store `GITHUB_TOKEN` and `OPENAI_API_KEY` outside source control; `.env` is ignored.
 - Pull request titles, descriptions, filenames, documentation, and patches are untrusted data and are explicitly separated from review instructions.
 - The CLI never executes changed code or arbitrary shell commands from a pull request.
+- The reusable Action is intended for the `pull_request` event with least-privilege `contents: read` and `pull-requests: read` permissions. It does not use `pull_request_target`, which has a different trust model and can expose secrets to untrusted workflow context.
+- GitHub does not expose repository secrets to workflows triggered by pull requests from forks. Fork reviews therefore need an explicit maintainer-approved credential strategy; the Action does not bypass this restriction.
+- The Action runs the trusted Action checkout only. It does not check out or execute the contributor's pull request, and it appends the Markdown report to `GITHUB_STEP_SUMMARY` rather than posting comments by default.
 - Reports may contain code-derived text, so review output before sharing it outside the intended maintainer context.
 - Provider and GitHub errors are normalized without intentionally printing credentials.

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -5,6 +5,7 @@ const supportedActions = new Set(['opened', 'synchronize', 'reopened']);
 export interface PullRequestEvent {
   url: string;
   number: number;
+  isFork: boolean;
 }
 
 export function parsePullRequestEvent(value: unknown): PullRequestEvent {
@@ -14,7 +15,12 @@ export function parsePullRequestEvent(value: unknown): PullRequestEvent {
 
   const event = value as {
     action?: unknown;
-    pull_request?: { number?: unknown; html_url?: unknown };
+    pull_request?: {
+      number?: unknown;
+      html_url?: unknown;
+      base?: { repo?: { full_name?: unknown } };
+      head?: { repo?: { full_name?: unknown } };
+    };
   };
   if (typeof event.action !== 'string' || !supportedActions.has(event.action)) {
     throw new Error('This Action supports only opened, synchronize, or reopened pull requests.');
@@ -27,5 +33,9 @@ export function parsePullRequestEvent(value: unknown): PullRequestEvent {
   if (event.pull_request.number !== undefined && event.pull_request.number !== parsed.number) {
     throw new Error('GitHub event pull request number does not match its URL.');
   }
-  return { url: event.pull_request.html_url, number: parsed.number };
+  const baseName = event.pull_request.base?.repo?.full_name;
+  const headName = event.pull_request.head?.repo?.full_name;
+  const isFork =
+    typeof baseName === 'string' && typeof headName === 'string' && baseName !== headName;
+  return { url: event.pull_request.html_url, number: parsed.number, isFork };
 }

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -8,17 +8,19 @@ import { executeReview } from '../cli/commands/review.js';
 import { parsePullRequestEvent } from './event.js';
 import { buildActionReviewOptions, parseActionInputs, redactSecrets } from './inputs.js';
 import { writeActionReport } from './output.js';
+import { assertActionCredentialsAvailable } from './security.js';
 
 async function main(): Promise<void> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is required for the GitHub Action.');
+  const event = parsePullRequestEvent(JSON.parse(await readFile(eventPath, 'utf8')));
+  assertActionCredentialsAvailable(event, process.env);
   const inputs = parseActionInputs({
     GITHUB_TOKEN: process.env.GITHUB_TOKEN,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     ACTION_MODEL: process.env.ACTION_MODEL,
     ACTION_MIN_SEVERITY: process.env.ACTION_MIN_SEVERITY,
   });
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is required for the GitHub Action.');
-  const event = parsePullRequestEvent(JSON.parse(await readFile(eventPath, 'utf8')));
 
   process.env.GITHUB_TOKEN = inputs.githubToken;
   process.env.OPENAI_API_KEY = inputs.openAiApiKey;

--- a/src/action/security.ts
+++ b/src/action/security.ts
@@ -1,0 +1,10 @@
+export function assertActionCredentialsAvailable(
+  event: { isFork: boolean },
+  environment: { OPENAI_API_KEY?: string },
+): void {
+  if (event.isFork && !environment.OPENAI_API_KEY) {
+    throw new Error(
+      'OPENAI_API_KEY is unavailable for this fork pull request. GitHub does not expose repository secrets to pull_request workflows from forks.',
+    );
+  }
+}

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -7,9 +7,12 @@ import {
 } from '../src/action/inputs.js';
 import { parsePullRequestEvent } from '../src/action/event.js';
 import { writeActionReport } from '../src/action/output.js';
+import { assertActionCredentialsAvailable } from '../src/action/security.js';
+import { readFile as readTextFile } from 'node:fs/promises';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { URL } from 'node:url';
 
 describe('GitHub Action inputs', () => {
   it('parses required credentials and optional review settings', () => {
@@ -71,7 +74,45 @@ describe('GitHub pull request event', () => {
     ).toEqual({
       url: 'https://github.com/octo/project/pull/12',
       number: 12,
+      isFork: false,
     });
+  });
+
+  it('marks pull requests from fork repositories without changing the event source', () => {
+    expect(
+      parsePullRequestEvent({
+        action: 'opened',
+        pull_request: {
+          number: 12,
+          html_url: 'https://github.com/octo/project/pull/12',
+          base: { repo: { full_name: 'octo/project' } },
+          head: { repo: { full_name: 'contributor/project' } },
+        },
+      }).isFork,
+    ).toBe(true);
+  });
+
+  it('recognizes same-repository pull requests as non-fork events', () => {
+    expect(
+      parsePullRequestEvent({
+        action: 'reopened',
+        pull_request: {
+          number: 12,
+          html_url: 'https://github.com/octo/project/pull/12',
+          base: { repo: { full_name: 'octo/project' } },
+          head: { repo: { full_name: 'octo/project' } },
+        },
+      }).isFork,
+    ).toBe(false);
+  });
+
+  it('explains why fork workflows cannot review without an OpenAI secret', () => {
+    expect(() =>
+      assertActionCredentialsAvailable(
+        { url: 'https://github.com/octo/project/pull/12', number: 12, isFork: true },
+        {},
+      ),
+    ).toThrow(/does not expose repository secrets to pull_request workflows from forks/);
   });
 
   it('rejects unsupported actions and missing pull request metadata', () => {
@@ -82,6 +123,16 @@ describe('GitHub pull request event', () => {
       }),
     ).toThrow(/opened, synchronize, or reopened/);
     expect(() => parsePullRequestEvent({ action: 'opened' })).toThrow(/pull_request/);
+  });
+});
+
+describe('GitHub Action security documentation', () => {
+  it('documents fork secret limitations and the pull_request trust model', async () => {
+    const security = await readTextFile(new URL('../SECURITY.md', import.meta.url), 'utf8');
+    expect(security).toMatch(/pull_request/);
+    expect(security).toMatch(/fork/i);
+    expect(security).toMatch(/pull_request_target/);
+    expect(security).toMatch(/GITHUB_STEP_SUMMARY/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Detect fork pull requests from event metadata without changing the event source.
- Explain the missing-secret behavior for fork workflows.
- Document `pull_request`, least-privilege permissions, `pull_request_target` risks, summary output, and the no-checkout/no-execution boundary.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 58 tests
- `npm run build`
- `npm run format:check`
- `git diff --check`

## Security
- The Action remains `pull_request`-oriented and does not use `pull_request_target`.
- Fork secret limitations are surfaced rather than bypassed.
- The Action does not check out or execute the reviewed contributor code.
- Review output remains advisory and is written to the job summary.

## Limitations
- Live GitHub/OpenAI Action testing remains pending because credentials are not used in CI.
