### PR TITLE
docs: add GitHub Action usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Pull request review often starts with the same context-gathering work: finding t
 - Validate OpenAI JSON responses with Zod.
 - Deduplicate identical findings and apply deterministic severity filtering.
 - Print Markdown to stdout or write it to `--output`.
-- Run lint, typecheck, tests, and build in GitHub Actions without secrets.
+- Run lint, typecheck, tests, and build in GitHub Actions without live review secrets.
 - Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 - Add repository-specific review rules and ignore paths without changing application code.
 - Reserve predictable prompt/response space with simple character-based context budget settings.
+- Run an opt-in GitHub Action that appends advisory reports to the Actions job summary.
 
 ## How It Works
 
@@ -103,6 +104,33 @@ ignore:
 
 The file is loaded from the pull request's base commit, not the PR branch, so a PR cannot silently change the policy used to review itself. CLI options override repository configuration, and configuration overrides application defaults. Rule text is treated as untrusted review guidance. Ignored files are excluded before AI review and shown in the report's skipped-file information. See [docs/configuration.md](docs/configuration.md) and [examples/oss-pr-reviewer.yml](examples/oss-pr-reviewer.yml).
 
+## GitHub Actions
+
+v0.3.0 adds an opt-in composite Action for `pull_request` events. It reuses the CLI, reads the trusted base-branch configuration, and appends the Markdown report to the job summary. It does not post comments or execute the reviewed PR.
+
+```yaml
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vuphongle/oss-pr-reviewer@v0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+Live Action reviews require `OPENAI_API_KEY`; tests and local development do not. Fork pull requests normally cannot access repository secrets under `pull_request`, so do not switch to `pull_request_target` casually. See [docs/github-actions.md](docs/github-actions.md) for permissions, inputs, security boundaries, and limitations.
+
 ## CLI Usage
 
 ```bash
@@ -159,7 +187,7 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 - The tool reviews supplied pull request metadata and patches rather than the full repository.
 - GitHub-truncated, missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
 - Context budgeting uses character approximations rather than exact model tokenization.
-- It does not post comments, create annotations, clone repositories, run tests, or replace human/security review.
+- The GitHub Action does not post comments or create annotations; it writes a job summary only. The CLI does not clone repositories or run tests.
 - Live API usage requires network access and valid credentials; automated tests use mocks.
 
 ## Development and Testing
@@ -176,9 +204,9 @@ Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md). CI runs the same
 
 ## Roadmap
 
-These are possible future directions, not v0.2.0 features:
+These are possible future directions, not current features:
 
-- **v0.3:** a GitHub Action, automatic PR comments, inline annotations, and richer maintainer integrations.
+- **v0.4:** optional PR comments or annotations, subject to a separate permission and duplicate-output design.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,10 @@
 `oss-pr-reviewer` is a single-process CLI. It fetches only the requested pull request, trusted-base configuration, and changed-file patches; it does not clone or execute the repository.
 
 ```text
+GitHub pull_request event
+  |
+Composite Action (optional)
+  |
 CLI
   |
 GitHub Client
@@ -26,6 +30,8 @@ Zod validation
 Finding merge / deduplicate / filter
   |
 Markdown renderer
+  |
+GITHUB_STEP_SUMMARY
 ```
 
 ## Boundaries
@@ -40,7 +46,11 @@ Markdown renderer
 - `src/ai/` contains the OpenAI SDK boundary. The rest of the review engine depends on the small `ReviewProvider` interface.
 - `src/review/schema.ts` validates every provider response before it enters the merge pipeline.
 - `src/report/` renders the final report without making claims that automated review is definitive.
+- `action.yml` is a thin composite Action. It builds and runs only the trusted Action checkout, parses supported pull request event metadata, and appends the existing Markdown report to the job summary.
+- `src/action/` contains testable Action-boundary code for event parsing, input validation, secret redaction, fork limitations, and summary output. It does not duplicate review logic.
 
 Custom rule descriptions are passed as untrusted user-context guidance. They cannot replace or modify the system review policy.
 
 The review prompt labels all pull request content as untrusted data. No changed code is executed, and no repository content outside the supplied pull request is sent to the provider.
+
+The documented workflow uses `pull_request`, read-only permissions, and a tagged Action release. Fork pull requests normally cannot receive repository secrets; the Action does not use `pull_request_target` as a workaround.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,69 @@
+# GitHub Actions
+
+`oss-pr-reviewer` v0.3.0 includes an opt-in composite GitHub Action for advisory pull request reviews. It reuses the existing CLI and review engine, then appends the generated Markdown report to the workflow job summary through `GITHUB_STEP_SUMMARY`.
+
+## Enable the Action
+
+Add a workflow such as [examples/github-actions/basic.yml](../examples/github-actions/basic.yml):
+
+```yaml
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vuphongle/oss-pr-reviewer@v0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+The example uses the tagged release rather than `main`. Pin the Action to a reviewed release or commit according to your repository's dependency policy.
+
+## Inputs
+
+| Input            | Required | Default                    | Purpose                                                                         |
+| ---------------- | -------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `github-token`   | yes      | none                       | Token used to read PR metadata, patches, and trusted base-branch configuration. |
+| `openai-api-key` | yes      | none                       | Key used for the OpenAI review request.                                         |
+| `model`          | no       | `gpt-4o-mini`              | OpenAI model name.                                                              |
+| `min-severity`   | no       | repository config or `low` | Finding threshold. CLI/Action input overrides repository configuration.         |
+
+The Action is advisory. A high or critical finding does not fail the job; configuration, API, or runtime failures do.
+
+## Permissions and Secrets
+
+Use the narrow permissions shown above:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+```
+
+Store `OPENAI_API_KEY` as a repository or organization secret. The Action does not print secrets, place them in reports, or post PR comments. It does not request write permissions.
+
+The Action does not use `pull_request_target`. It runs the trusted Action checkout and does not check out or execute the reviewed contributor branch.
+
+## Fork Pull Requests
+
+GitHub normally withholds repository secrets from workflows triggered by `pull_request` events from forks. That means `OPENAI_API_KEY` is unavailable for an untrusted fork workflow in the normal setup. Do not expose the key by switching casually to `pull_request_target` or by executing fork code.
+
+Maintainers can review fork changes using a separate, explicitly approved workflow design, but that is outside this release. The Action does not bypass GitHub's secret protections.
+
+## Repository Configuration
+
+The existing `.oss-pr-reviewer.yml` is loaded from the pull request base commit. Repository rules, ignored paths, and context budgets continue to use v0.2 trust boundaries. The PR branch cannot silently activate a different policy for its own review.
+
+## Output and Limitations
+
+The report is appended to the Actions job summary. The Action does not post or update PR comments, create annotations, or enforce a merge policy. Live GitHub/OpenAI credentials are not needed for repository tests, but a real Action run requires valid secrets and network access.

--- a/examples/github-actions/basic.yml
+++ b/examples/github-actions/basic.yml
@@ -1,0 +1,21 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run oss-pr-reviewer
+        uses: vuphongle/oss-pr-reviewer@v0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-4o-mini
+          min-severity: medium

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -134,6 +134,18 @@ describe('GitHub Action security documentation', () => {
     expect(security).toMatch(/pull_request_target/);
     expect(security).toMatch(/GITHUB_STEP_SUMMARY/);
   });
+
+  it('keeps the documented workflow on pull_request with read-only permissions', async () => {
+    const workflow = await readTextFile(
+      new URL('../examples/github-actions/basic.yml', import.meta.url),
+      'utf8',
+    );
+    expect(workflow).toMatch(/pull_request:/);
+    expect(workflow).toMatch(/contents: read/);
+    expect(workflow).toMatch(/pull-requests: read/);
+    expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.3\.0/);
+    expect(workflow).not.toMatch(/pull_request_target/);
+  });
 });
 
 describe('GitHub Action report output', () => {


### PR DESCRIPTION
## Summary
- Add a tagged-release workflow example for the opt-in composite Action.
- Document Action inputs, read-only permissions, job-summary output, repository config, and fork secret limitations.
- Update README and architecture docs for the v0.3 Action path.
- Add static tests for the documented workflow trust model.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 59 tests
- `npm run build`
- `npm run format:check`
- workflow YAML parse check
- `git diff --check`

## Security
- Documentation uses `pull_request`, `contents: read`, and `pull-requests: read`.
- The workflow does not use `pull_request_target` or checkout the reviewed PR.
- Secrets remain explicit inputs and are not written to reports or logs.

## Limitations
- The example references `@v0.3.0`, which will be valid after the release PR is merged and the tag is published.
- The Action remains summary-only; PR comments and annotations are deferred.
- Live Action testing remains pending because credentials are not used in CI.
