### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.0
+
+- Added an opt-in composite GitHub Action for `pull_request` events with `opened`, `synchronize`, and `reopened` actions.
+- Added least-privilege, summary-only workflow guidance using `contents: read` and `pull-requests: read`.
+- Added Action input validation, fork-secret limitation handling, secret redaction, and deterministic Action boundary tests.
+- Added GitHub Actions usage documentation and a tagged-release workflow example.
+
+The Action does not use `pull_request_target`, check out contributor code, post PR comments, or fail a job because a review contains high or critical findings. Live GitHub/OpenAI Action smoke testing remains pending; automated validation uses deterministic mocks, fixtures, and static workflow checks.
+
 ## 0.2.0
 
 - Added optional trusted-base `.oss-pr-reviewer.yml` configuration with validated CLI precedence.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install
 npm run build
 ```
 
-The v0.2.0 release is package-ready but is not published to npm by this repository yet. Run the CLI from the checkout with `node dist/cli/index.js`, or use `npm link` for a local global command:
+The v0.3.0 release is package-ready but is not published to npm by this repository yet. Run the CLI from the checkout with `node dist/cli/index.js`, or use `npm link` for a local global command:
 
 ```bash
 npm link
@@ -171,7 +171,7 @@ The full report also includes pull request metadata, summary, statistics, skippe
 
 ## Architecture
 
-The CLI depends on a small `ReviewProvider` interface, so the review engine does not contain OpenAI SDK details. v0.2.0 ships one provider: OpenAI. Review content, repository rules, and ignored-path configuration are treated as untrusted repository data; changed code is never executed. See [docs/architecture.md](docs/architecture.md).
+The CLI depends on a small `ReviewProvider` interface, so the review engine does not contain OpenAI SDK details. v0.3.0 ships one provider: OpenAI. Review content, repository rules, and ignored-path configuration are treated as untrusted repository data; changed code is never executed. See [docs/architecture.md](docs/architecture.md).
 
 ## Review Philosophy
 
@@ -183,7 +183,7 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 
 ## Limitations
 
-- Only OpenAI is implemented in v0.2.0.
+- Only OpenAI is implemented in v0.3.0.
 - The tool reviews supplied pull request metadata and patches rather than the full repository.
 - GitHub-truncated, missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
 - Context budgeting uses character approximations rather than exact model tokenization.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Repository Configuration
 
-v0.2.0 supports an optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes.
+v0.3.0 supports the optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes. The same behavior is used by the GitHub Action.
 
 ## Example
 

--- a/docs/review-format.md
+++ b/docs/review-format.md
@@ -1,6 +1,6 @@
 # Review Format
 
-The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. v0.2.0 statistics also include files changed, files ignored by configuration, and review batches.
+The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. v0.3.0 keeps the v0.2.0 statistics, including files changed, files ignored by configuration, and review batches. The GitHub Action places the same report in the Actions job summary.
 
 ## Severity
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-pr-reviewer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-pr-reviewer",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-pr-reviewer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI-powered CLI for reviewing GitHub pull requests, detecting potential bugs, security risks, regressions, and missing tests, with structured Markdown reports for open-source maintainers.",
   "type": "module",
   "bin": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,7 @@ const program = new Command()
   .description(
     'AI-powered CLI for reviewing GitHub pull requests with structured Markdown reports.',
   )
-  .version('0.2.0');
+  .version('0.3.0');
 
 program
   .command('review')

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -11,7 +11,7 @@ describe('CLI input parsing', () => {
     const packageJson = JSON.parse(
       await readFile(new URL('../package.json', import.meta.url), 'utf8'),
     ) as { version: string };
-    expect(packageJson.version).toBe('0.2.0');
+    expect(packageJson.version).toBe('0.3.0');
   });
   it('parses owner/repository', () =>
     expect(parseRepository('octo/project')).toEqual({ owner: 'octo', repository: 'project' }));


### PR DESCRIPTION
## Summary
- Bump the package and CLI version to `0.3.0`.
- Add the v0.3.0 changelog entry for the opt-in GitHub Action.
- Align README and v0.2 documentation references with the new release.

## Features included in v0.3.0
- Composite GitHub Action for `pull_request` events.
- Summary-only Markdown output through `GITHUB_STEP_SUMMARY`.
- Read-only permission guidance and fork-secret documentation.
- Tagged workflow example and Action boundary tests.

## Testing
- `npm install` — PASS, 0 vulnerabilities
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run test` — PASS, 59 tests
- `npm run build` — PASS
- `npm run format:check` — PASS
- YAML parse checks — PASS
- CLI version/help checks — PASS
- `npm pack --dry-run` — PASS
- `git diff --check` — PASS

## Security
- No credentials committed.
- The Action remains summary-only with least-privilege read permissions documented.
- `pull_request_target` is not used.
- Reviewed PR code is not checked out or executed.

## Live integration
Real GitHub/OpenAI Action smoke testing remains pending because credentials were not used in CI.
