### PR TITLE
feat: add idempotent PR comment publishing

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -4,13 +4,14 @@ import { Buffer } from 'node:buffer';
 import type { PullRequest } from '../types.js';
 import type { RepositoryReference } from './types.js';
 import type { RepositoryFileReader } from '../config/repository.js';
+import type { ReviewComment, ReviewCommentClient } from './comments.js';
 
 interface GithubClientOptions {
   token?: string;
   octokit?: Octokit;
 }
 
-export class GithubClient implements RepositoryFileReader {
+export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
   private readonly octokit: Octokit;
 
   constructor(options: GithubClientOptions = {}) {
@@ -72,6 +73,67 @@ export class GithubClient implements RepositoryFileReader {
     } catch (error) {
       const candidate = error as { status?: number };
       if (candidate.status === 404) return undefined;
+      throw normalizeGithubError(error);
+    }
+  }
+
+  async listComments(
+    reference: RepositoryReference,
+    pullRequestNumber: number,
+  ): Promise<ReviewComment[]> {
+    try {
+      const comments = await this.octokit.paginate(this.octokit.issues.listComments, {
+        owner: reference.owner,
+        repo: reference.repository,
+        issue_number: pullRequestNumber,
+        per_page: 100,
+      });
+      return comments.map((comment) => ({
+        id: comment.id,
+        body: comment.body ?? '',
+        htmlUrl: comment.html_url,
+        user: comment.user
+          ? { type: comment.user.type, login: comment.user.login ?? undefined }
+          : undefined,
+      }));
+    } catch (error) {
+      throw normalizeGithubError(error);
+    }
+  }
+
+  async createComment(
+    reference: RepositoryReference,
+    pullRequestNumber: number,
+    body: string,
+  ): Promise<Pick<ReviewComment, 'id' | 'htmlUrl'>> {
+    try {
+      const response = await this.octokit.issues.createComment({
+        owner: reference.owner,
+        repo: reference.repository,
+        issue_number: pullRequestNumber,
+        body,
+      });
+      return { id: response.data.id, htmlUrl: response.data.html_url };
+    } catch (error) {
+      throw normalizeGithubError(error);
+    }
+  }
+
+  async updateComment(
+    reference: RepositoryReference,
+    pullRequestNumber: number,
+    commentId: number,
+    body: string,
+  ): Promise<Pick<ReviewComment, 'id' | 'htmlUrl'>> {
+    try {
+      const response = await this.octokit.issues.updateComment({
+        owner: reference.owner,
+        repo: reference.repository,
+        comment_id: commentId,
+        body,
+      });
+      return { id: response.data.id, htmlUrl: response.data.html_url };
+    } catch (error) {
       throw normalizeGithubError(error);
     }
   }

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -1,0 +1,88 @@
+import type { RepositoryReference } from './types.js';
+
+export const OSS_PR_REVIEWER_MARKER = '<!-- oss-pr-reviewer -->';
+const OWNED_COMMENT_AUTHORS = new Set(['github-actions[bot]', 'oss-pr-reviewer[bot]']);
+
+export interface ReviewComment {
+  id: number;
+  body: string;
+  user?: { type?: string; login?: string };
+  htmlUrl?: string;
+}
+
+export interface ReviewCommentClient {
+  listComments(reference: RepositoryReference, pullRequestNumber: number): Promise<ReviewComment[]>;
+  createComment(
+    reference: RepositoryReference,
+    pullRequestNumber: number,
+    body: string,
+  ): Promise<Pick<ReviewComment, 'id' | 'htmlUrl'>>;
+  updateComment(
+    reference: RepositoryReference,
+    pullRequestNumber: number,
+    commentId: number,
+    body: string,
+  ): Promise<Pick<ReviewComment, 'id' | 'htmlUrl'>>;
+}
+
+export interface PublishedReviewComment {
+  action: 'created' | 'updated';
+  id: number;
+  htmlUrl?: string;
+}
+
+export async function findReviewComment(
+  client: Pick<ReviewCommentClient, 'listComments'>,
+  reference: RepositoryReference,
+  pullRequestNumber: number,
+): Promise<ReviewComment | undefined> {
+  try {
+    const comments = await client.listComments(reference, pullRequestNumber);
+    return comments
+      .filter(
+        (comment) =>
+          comment.user?.type === 'Bot' &&
+          typeof comment.user.login === 'string' &&
+          OWNED_COMMENT_AUTHORS.has(comment.user.login) &&
+          comment.body.startsWith(OSS_PR_REVIEWER_MARKER),
+      )
+      .sort((left, right) => right.id - left.id)[0];
+  } catch (error) {
+    throw normalizeCommentError(error);
+  }
+}
+
+export async function publishReviewComment(
+  client: ReviewCommentClient,
+  reference: RepositoryReference,
+  pullRequestNumber: number,
+  report: string,
+): Promise<PublishedReviewComment> {
+  const body = `${OSS_PR_REVIEWER_MARKER}\n\n${report}`;
+  const existing = await findReviewComment(client, reference, pullRequestNumber);
+  try {
+    if (existing) {
+      const updated = await client.updateComment(reference, pullRequestNumber, existing.id, body);
+      return { action: 'updated', id: updated.id, htmlUrl: updated.htmlUrl };
+    }
+    const created = await client.createComment(reference, pullRequestNumber, body);
+    return { action: 'created', id: created.id, htmlUrl: created.htmlUrl };
+  } catch (error) {
+    throw normalizeCommentError(error);
+  }
+}
+
+function normalizeCommentError(error: unknown): Error {
+  const candidate = error as { status?: number; message?: string };
+  if (candidate.status === 401)
+    return new Error('GitHub comment API authentication failed. Check GITHUB_TOKEN.');
+  if (candidate.status === 403)
+    return new Error(
+      'GitHub comment API access was denied. Comment mode requires pull-requests: write permission.',
+    );
+  if (candidate.status === 404)
+    return new Error('GitHub pull request comment endpoint was not found or is not accessible.');
+  return new Error(
+    `GitHub comment API request failed${candidate.message ? `: ${candidate.message}` : '.'}`,
+  );
+}

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  OSS_PR_REVIEWER_MARKER,
+  findReviewComment,
+  publishReviewComment,
+} from '../src/github/comments.js';
+import type { RepositoryReference } from '../src/github/types.js';
+
+const reference: RepositoryReference = { owner: 'octo', repository: 'project' };
+
+describe('PR comment publishing', () => {
+  it('finds only the newest comment with the stable marker from the expected bot', async () => {
+    const client = {
+      listComments: vi.fn().mockResolvedValue([
+        {
+          id: 10,
+          body: `${OSS_PR_REVIEWER_MARKER}\nold`,
+          user: { type: 'Bot', login: 'github-actions[bot]' },
+        },
+        { id: 12, body: 'unrelated', user: { type: 'User' } },
+        {
+          id: 11,
+          body: `${OSS_PR_REVIEWER_MARKER}\nnew`,
+          user: { type: 'Bot', login: 'github-actions[bot]' },
+        },
+        { id: 13, body: `${OSS_PR_REVIEWER_MARKER}\nuser copy`, user: { type: 'User' } },
+      ]),
+    };
+
+    await expect(findReviewComment(client, reference, 7)).resolves.toEqual({
+      id: 11,
+      body: `${OSS_PR_REVIEWER_MARKER}\nnew`,
+      user: { type: 'Bot', login: 'github-actions[bot]' },
+    });
+  });
+
+  it('creates one comment when no owned marker comment exists', async () => {
+    const client = {
+      listComments: vi.fn().mockResolvedValue([]),
+      createComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
+      updateComment: vi.fn(),
+    };
+
+    await expect(publishReviewComment(client, reference, 7, '## Review')).resolves.toEqual({
+      action: 'created',
+      id: 22,
+      htmlUrl: 'https://example.test/c/22',
+    });
+    expect(client.createComment).toHaveBeenCalledWith(
+      reference,
+      7,
+      `${OSS_PR_REVIEWER_MARKER}\n\n## Review`,
+    );
+    expect(client.updateComment).not.toHaveBeenCalled();
+  });
+
+  it('updates the owned marker comment and remains idempotent on repeated runs', async () => {
+    const client = {
+      listComments: vi.fn().mockResolvedValue([
+        {
+          id: 22,
+          body: `${OSS_PR_REVIEWER_MARKER}\nold`,
+          user: { type: 'Bot', login: 'github-actions[bot]' },
+        },
+      ]),
+      createComment: vi.fn(),
+      updateComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
+    };
+
+    await expect(publishReviewComment(client, reference, 7, '## Updated')).resolves.toEqual({
+      action: 'updated',
+      id: 22,
+      htmlUrl: 'https://example.test/c/22',
+    });
+    await expect(publishReviewComment(client, reference, 7, '## Updated again')).resolves.toEqual({
+      action: 'updated',
+      id: 22,
+      htmlUrl: 'https://example.test/c/22',
+    });
+    expect(client.createComment).not.toHaveBeenCalled();
+    expect(client.updateComment).toHaveBeenNthCalledWith(
+      1,
+      reference,
+      7,
+      22,
+      `${OSS_PR_REVIEWER_MARKER}\n\n## Updated`,
+    );
+    expect(client.updateComment).toHaveBeenNthCalledWith(
+      2,
+      reference,
+      7,
+      22,
+      `${OSS_PR_REVIEWER_MARKER}\n\n## Updated again`,
+    );
+  });
+
+  it('normalizes GitHub comment permission failures', async () => {
+    const client = {
+      listComments: vi.fn().mockRejectedValue({ status: 403 }),
+    };
+
+    await expect(findReviewComment(client, reference, 7)).rejects.toThrow(/comment API access/);
+  });
+});

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -89,4 +89,61 @@ describe('GitHub client', () => {
       ),
     ).resolves.toBeUndefined();
   });
+
+  it('normalizes PR comment list, create, and update API calls', async () => {
+    const octokit = {
+      issues: {
+        listComments: vi.fn(),
+        createComment: vi.fn().mockResolvedValue({
+          data: { id: 22, html_url: 'https://github.test/comments/22' },
+        }),
+        updateComment: vi.fn().mockResolvedValue({
+          data: { id: 22, html_url: 'https://github.test/comments/22' },
+        }),
+      },
+      paginate: vi.fn().mockResolvedValue([
+        {
+          id: 22,
+          body: '<!-- oss-pr-reviewer -->\nreport',
+          html_url: 'https://github.test/comments/22',
+          user: { type: 'Bot', login: 'github-actions[bot]' },
+        },
+      ]),
+    };
+    const client = new GithubClient({ octokit: octokit as never });
+
+    await expect(client.listComments(reference, 7)).resolves.toMatchObject([
+      {
+        id: 22,
+        body: '<!-- oss-pr-reviewer -->\nreport',
+        user: { type: 'Bot', login: 'github-actions[bot]' },
+      },
+    ]);
+    await expect(client.createComment(reference, 7, 'body')).resolves.toEqual({
+      id: 22,
+      htmlUrl: 'https://github.test/comments/22',
+    });
+    await expect(client.updateComment(reference, 7, 22, 'updated')).resolves.toEqual({
+      id: 22,
+      htmlUrl: 'https://github.test/comments/22',
+    });
+    expect(octokit.paginate).toHaveBeenCalledWith(octokit.issues.listComments, {
+      owner: 'octo',
+      repo: 'project',
+      issue_number: 7,
+      per_page: 100,
+    });
+    expect(octokit.issues.createComment).toHaveBeenCalledWith({
+      owner: 'octo',
+      repo: 'project',
+      issue_number: 7,
+      body: 'body',
+    });
+    expect(octokit.issues.updateComment).toHaveBeenCalledWith({
+      owner: 'octo',
+      repo: 'project',
+      comment_id: 22,
+      body: 'updated',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add a small GitHub PR comment adapter with a stable `<!-- oss-pr-reviewer -->` marker.
- Find only owned bot comments, choose the newest matching comment, and leave older duplicates untouched.
- Create one comment when none exists or update the existing comment on repeated runs.
- Reuse the existing `GithubClient`/Octokit boundary with deterministic tests.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 64 tests
- `npm run format:check`
- `git diff --check`

## Security
- Comment updates require an exact stable marker and an expected bot login (`github-actions[bot]` or `oss-pr-reviewer[bot]`).
- Unrelated user comments are never modified.
- Older duplicate tool comments are not deleted.
- No workflow permissions or Action behavior change in this PR.

## Limitations
- The adapter is not wired to Action comment mode yet; that is the next focused PR.
- Live GitHub API comment testing remains pending; tests use mocked Octokit behavior.
