### PR TITLE
feat: add opt-in GitHub Action comment mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: oss-pr-reviewer
-description: Run an advisory AI review for a pull_request and append the Markdown report to the job summary.
+description: Run an advisory AI review for a pull_request, append the report to the job summary, and optionally update a PR comment.
 author: oss-pr-reviewer maintainers
 inputs:
   github-token:
@@ -15,6 +15,17 @@ inputs:
   min-severity:
     description: Minimum finding severity to include in the report.
     required: false
+  post-comment:
+    description: Publish or update the review comment on the pull request. Must be true or false.
+    required: false
+    default: 'false'
+outputs:
+  comment-action:
+    description: Whether the comment was created, updated, or skipped.
+  comment-id:
+    description: ID of the created or updated comment, when comment mode is enabled.
+  comment-url:
+    description: URL of the created or updated comment, when available.
 runs:
   using: composite
   steps:
@@ -26,6 +37,7 @@ runs:
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         ACTION_MODEL: ${{ inputs.model }}
         ACTION_MIN_SEVERITY: ${{ inputs.min-severity }}
+        ACTION_POST_COMMENT: ${{ inputs.post-comment }}
       run: |
         set -euo pipefail
         npm ci --ignore-scripts --prefix "$ACTION_PATH"

--- a/src/action/comment.ts
+++ b/src/action/comment.ts
@@ -1,0 +1,15 @@
+import { parsePullRequestUrl } from '../github/types.js';
+import { publishReviewComment } from '../github/comments.js';
+import type { ReviewCommentClient, PublishedReviewComment } from '../github/comments.js';
+import type { PullRequestEvent } from './event.js';
+
+export async function publishActionComment(
+  client: ReviewCommentClient,
+  event: PullRequestEvent,
+  report: string,
+  enabled: boolean,
+): Promise<PublishedReviewComment | undefined> {
+  if (!enabled) return undefined;
+  const parsed = parsePullRequestUrl(event.url);
+  return publishReviewComment(client, parsed.repository, event.number, report);
+}

--- a/src/action/inputs.ts
+++ b/src/action/inputs.ts
@@ -9,6 +9,7 @@ export interface ActionInputs {
   openAiApiKey: string;
   model?: string;
   minSeverity?: Severity;
+  postComment: boolean;
 }
 
 export interface ActionEnvironment {
@@ -16,6 +17,7 @@ export interface ActionEnvironment {
   OPENAI_API_KEY?: string;
   ACTION_MODEL?: string;
   ACTION_MIN_SEVERITY?: string;
+  ACTION_POST_COMMENT?: string;
 }
 
 export function parseActionInputs(environment: ActionEnvironment): ActionInputs {
@@ -31,12 +33,17 @@ export function parseActionInputs(environment: ActionEnvironment): ActionInputs 
       `Unsupported Action severity '${rawSeverity}'. Choose low, medium, high, or critical.`,
     );
   }
+  const rawPostComment = environment.ACTION_POST_COMMENT?.trim() || 'false';
+  if (rawPostComment !== 'true' && rawPostComment !== 'false') {
+    throw new Error("Invalid post-comment value. Use 'true' or 'false'.");
+  }
 
   return {
     githubToken,
     openAiApiKey,
     model,
     minSeverity: rawSeverity as Severity | undefined,
+    postComment: rawPostComment === 'true',
   };
 }
 

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -5,10 +5,12 @@ import { join } from 'node:path';
 import process from 'node:process';
 
 import { executeReview } from '../cli/commands/review.js';
+import { GithubClient } from '../github/client.js';
 import { parsePullRequestEvent } from './event.js';
 import { buildActionReviewOptions, parseActionInputs, redactSecrets } from './inputs.js';
-import { writeActionReport } from './output.js';
+import { writeActionOutput, writeActionReport } from './output.js';
 import { assertActionCredentialsAvailable } from './security.js';
+import { publishActionComment } from './comment.js';
 
 async function main(): Promise<void> {
   const eventPath = process.env.GITHUB_EVENT_PATH;
@@ -20,6 +22,7 @@ async function main(): Promise<void> {
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     ACTION_MODEL: process.env.ACTION_MODEL,
     ACTION_MIN_SEVERITY: process.env.ACTION_MIN_SEVERITY,
+    ACTION_POST_COMMENT: process.env.ACTION_POST_COMMENT,
   });
 
   process.env.GITHUB_TOKEN = inputs.githubToken;
@@ -27,6 +30,17 @@ async function main(): Promise<void> {
   const report = await executeReview(buildActionReviewOptions(event, inputs));
   const reportPath = join(process.env.RUNNER_TEMP ?? process.cwd(), 'oss-pr-reviewer-report.md');
   await writeActionReport(report, reportPath, process.env.GITHUB_STEP_SUMMARY);
+  const published = await publishActionComment(
+    new GithubClient({ token: inputs.githubToken }),
+    event,
+    report,
+    inputs.postComment,
+  );
+  await writeActionOutput(process.env.GITHUB_OUTPUT, {
+    'comment-action': published?.action ?? 'skipped',
+    'comment-id': published ? String(published.id) : '',
+    'comment-url': published?.htmlUrl ?? '',
+  });
 }
 
 try {

--- a/src/action/output.ts
+++ b/src/action/output.ts
@@ -1,4 +1,5 @@
 import { appendFile, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
 
 export async function writeActionReport(
   report: string,
@@ -7,4 +8,16 @@ export async function writeActionReport(
 ): Promise<void> {
   await writeFile(reportPath, report, 'utf8');
   if (summaryPath) await appendFile(summaryPath, `${report.trimEnd()}\n`, 'utf8');
+}
+
+export async function writeActionOutput(
+  outputPath: string | undefined,
+  values: Record<string, string>,
+): Promise<void> {
+  if (!outputPath) return;
+  const lines = Object.entries(values).map(([name, value]) => {
+    const delimiter = `oss_pr_reviewer_${randomUUID()}`;
+    return `${name}<<${delimiter}\n${value}\n${delimiter}`;
+  });
+  await appendFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildActionReviewOptions,
@@ -7,7 +7,10 @@ import {
 } from '../src/action/inputs.js';
 import { parsePullRequestEvent } from '../src/action/event.js';
 import { writeActionReport } from '../src/action/output.js';
+import { writeActionOutput } from '../src/action/output.js';
 import { assertActionCredentialsAvailable } from '../src/action/security.js';
+import { publishActionComment } from '../src/action/comment.js';
+import { OSS_PR_REVIEWER_MARKER } from '../src/github/comments.js';
 import { readFile as readTextFile } from 'node:fs/promises';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -22,12 +25,14 @@ describe('GitHub Action inputs', () => {
         OPENAI_API_KEY: 'openai-key',
         ACTION_MODEL: 'gpt-test',
         ACTION_MIN_SEVERITY: 'high',
+        ACTION_POST_COMMENT: 'true',
       }),
     ).toEqual({
       githubToken: 'github-token',
       openAiApiKey: 'openai-key',
       model: 'gpt-test',
       minSeverity: 'high',
+      postComment: true,
     });
   });
 
@@ -40,6 +45,26 @@ describe('GitHub Action inputs', () => {
         ACTION_MIN_SEVERITY: 'urgent',
       }),
     ).toThrow(/severity/);
+    expect(() =>
+      parseActionInputs({
+        GITHUB_TOKEN: 'github-token',
+        OPENAI_API_KEY: 'openai-key',
+        ACTION_POST_COMMENT: 'sometimes',
+      }),
+    ).toThrow(/post-comment/);
+  });
+
+  it('defaults comment publishing to disabled and accepts false explicitly', () => {
+    expect(
+      parseActionInputs({ GITHUB_TOKEN: 'github-token', OPENAI_API_KEY: 'openai-key' }).postComment,
+    ).toBe(false);
+    expect(
+      parseActionInputs({
+        GITHUB_TOKEN: 'github-token',
+        OPENAI_API_KEY: 'openai-key',
+        ACTION_POST_COMMENT: 'false',
+      }).postComment,
+    ).toBe(false);
   });
 
   it('maps action inputs to the existing review command contract', () => {
@@ -146,6 +171,15 @@ describe('GitHub Action security documentation', () => {
     expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.3\.0/);
     expect(workflow).not.toMatch(/pull_request_target/);
   });
+
+  it('declares opt-in comment mode and stable outputs in action.yml', async () => {
+    const action = await readTextFile(new URL('../action.yml', import.meta.url), 'utf8');
+    expect(action).toMatch(/post-comment:/);
+    expect(action).toMatch(/default: 'false'/);
+    expect(action).toMatch(/comment-action:/);
+    expect(action).toMatch(/comment-id:/);
+    expect(action).toMatch(/comment-url:/);
+  });
 });
 
 describe('GitHub Action report output', () => {
@@ -158,5 +192,49 @@ describe('GitHub Action report output', () => {
 
     await expect(readFile(reportPath, 'utf8')).resolves.toBe('# Report\n');
     await expect(readFile(summaryPath, 'utf8')).resolves.toBe('# Report\n');
+  });
+
+  it('writes stable action outputs using the GitHub output protocol', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'oss-pr-reviewer-action-output-'));
+    const outputPath = join(directory, 'output');
+
+    await writeActionOutput(outputPath, { 'comment-action': 'created', 'comment-id': '22' });
+
+    const output = await readFile(outputPath, 'utf8');
+    expect(output).toMatch(/comment-action<<.*\ncreated\n/);
+    expect(output).toMatch(/comment-id<<.*\n22\n/);
+  });
+
+  it('does not call GitHub comments when comment mode is disabled', async () => {
+    const client = { listComments: vi.fn() };
+    await expect(
+      publishActionComment(
+        client as never,
+        { url: 'https://github.com/octo/project/pull/7', number: 7, isFork: false },
+        '## Review',
+        false,
+      ),
+    ).resolves.toBeUndefined();
+    expect(client.listComments).not.toHaveBeenCalled();
+  });
+
+  it('publishes the existing report when comment mode is enabled', async () => {
+    const client = {
+      listComments: vi.fn().mockResolvedValue([]),
+      createComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
+    };
+    await expect(
+      publishActionComment(
+        client as never,
+        { url: 'https://github.com/octo/project/pull/7', number: 7, isFork: false },
+        '## Review',
+        true,
+      ),
+    ).resolves.toEqual({ action: 'created', id: 22, htmlUrl: 'https://example.test/c/22' });
+    expect(client.createComment).toHaveBeenCalledWith(
+      { owner: 'octo', repository: 'project' },
+      7,
+      `${OSS_PR_REVIEWER_MARKER}\n\n## Review`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add the opt-in `post-comment` Action input, defaulting to `false`.
- Always write the complete report to `GITHUB_STEP_SUMMARY` first.
- When enabled, publish or update the owned PR comment through the reusable comment adapter.
- Expose `comment-action`, `comment-id`, and `comment-url` outputs.
- Reject arbitrary boolean strings instead of treating them as truthy.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 69 tests
- `npm run build`
- `npm run format:check`
- `git diff --check`

## Security
- Comment mode is disabled by default and is controlled by workflow input, not PR configuration.
- Summary-only workflows retain read-only behavior; comment permission guidance will be added in the documentation PR.
- Existing marker/ownership checks from the comment core are reused.
- Comment publishing does not execute reviewed PR code or use `pull_request_target`.

## Failure behavior
If comment mode is explicitly enabled and GitHub rejects the comment operation, the Action exits non-zero after the full summary has been written, so the requested write is not silently reported as successful.

## Limitations
- Comment size limits and mention-safe rendering are handled in the follow-up safety PR.
- Live GitHub comment API testing remains pending; tests use mocks.
