### PR TITLE
feat: bound and sanitize PR comment output

### DIFF
--- a/src/github/comment-constants.ts
+++ b/src/github/comment-constants.ts
@@ -1,0 +1,1 @@
+export const OSS_PR_REVIEWER_MARKER = '<!-- oss-pr-reviewer -->';

--- a/src/github/comment-safety.ts
+++ b/src/github/comment-safety.ts
@@ -1,0 +1,62 @@
+import { OSS_PR_REVIEWER_MARKER } from './comment-constants.js';
+
+export const MAX_REVIEW_COMMENT_CHARACTERS = 60_000;
+const TRUNCATION_NOTICE =
+  '> This comment was shortened because the complete review exceeded GitHub comment limits. See the GitHub Actions job summary for the full report.';
+const MENTION_GUARD = '@\u200b';
+
+export interface PreparedReviewComment {
+  body: string;
+  truncated: boolean;
+}
+
+export function prepareReviewComment(report: string): PreparedReviewComment {
+  const safeReport = neutralizeMentions(report);
+  const fullBody = `${OSS_PR_REVIEWER_MARKER}\n\n${safeReport}`;
+  if (fullBody.length <= MAX_REVIEW_COMMENT_CHARACTERS) {
+    return { body: fullBody, truncated: false };
+  }
+
+  const sections = safeReport.split(/(?=^#{2,4} )/m);
+  const header = sections.shift() ?? '';
+  const prioritized = sections
+    .map((section, index) => ({ section, index, priority: sectionPriority(section) }))
+    .sort((left, right) => right.priority - left.priority || left.index - right.index);
+  const prefix = `${OSS_PR_REVIEWER_MARKER}\n\n${header.trimEnd()}\n\n`;
+  const suffix = `\n\n${TRUNCATION_NOTICE}`;
+  const available = MAX_REVIEW_COMMENT_CHARACTERS - prefix.length - suffix.length;
+  let selected = '';
+  for (const item of prioritized) {
+    const candidate = `${selected}${item.section.trimEnd()}\n\n`;
+    if (candidate.length > available) continue;
+    selected = candidate;
+  }
+  if (!selected) {
+    selected = truncateAtLineBoundary(
+      prioritized[0]?.section ?? safeReport,
+      Math.max(0, available),
+    );
+  }
+  return { body: `${prefix}${selected.trimEnd()}${suffix}`, truncated: true };
+}
+
+function neutralizeMentions(value: string): string {
+  return value.replace(/@(?=[A-Za-z0-9_])/g, MENTION_GUARD);
+}
+
+function sectionPriority(section: string): number {
+  if (/critical/i.test(section)) return 5;
+  if (/high/i.test(section)) return 4;
+  if (/summary|risk|statistics/i.test(section)) return 3;
+  if (/medium/i.test(section)) return 2;
+  if (/low/i.test(section)) return 1;
+  return 0;
+}
+
+function truncateAtLineBoundary(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  const candidate = value.slice(0, limit);
+  const boundary = candidate.lastIndexOf('\n');
+  const firstBoundary = candidate.indexOf('\n');
+  return boundary > firstBoundary ? candidate.slice(0, boundary) : candidate.slice(0, limit);
+}

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -1,6 +1,8 @@
 import type { RepositoryReference } from './types.js';
+import { prepareReviewComment } from './comment-safety.js';
+import { OSS_PR_REVIEWER_MARKER } from './comment-constants.js';
 
-export const OSS_PR_REVIEWER_MARKER = '<!-- oss-pr-reviewer -->';
+export { OSS_PR_REVIEWER_MARKER } from './comment-constants.js';
 const OWNED_COMMENT_AUTHORS = new Set(['github-actions[bot]', 'oss-pr-reviewer[bot]']);
 
 export interface ReviewComment {
@@ -58,7 +60,7 @@ export async function publishReviewComment(
   pullRequestNumber: number,
   report: string,
 ): Promise<PublishedReviewComment> {
-  const body = `${OSS_PR_REVIEWER_MARKER}\n\n${report}`;
+  const body = prepareReviewComment(report).body;
   const existing = await findReviewComment(client, reference, pullRequestNumber);
   try {
     if (existing) {

--- a/tests/comment-safety.test.ts
+++ b/tests/comment-safety.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_REVIEW_COMMENT_CHARACTERS,
+  prepareReviewComment,
+} from '../src/github/comment-safety.js';
+
+describe('PR comment safety', () => {
+  it('keeps normal reports unchanged apart from the stable marker wrapper', () => {
+    expect(prepareReviewComment('## Summary\nNo findings.')).toEqual({
+      body: '<!-- oss-pr-reviewer -->\n\n## Summary\nNo findings.',
+      truncated: false,
+    });
+  });
+
+  it('neutralizes mention-like text without changing the review meaning', () => {
+    const result = prepareReviewComment('Contact @maintainer about `@org/team`.');
+    expect(result.body).toContain('@​maintainer');
+    expect(result.body).toContain('@​org/team');
+  });
+
+  it('retains the report header and highest-priority sections within the limit', () => {
+    const critical = '### CRITICAL - Security\n\nCritical evidence '.repeat(1000);
+    const low = '### LOW - Maintainability\n\nLow detail '.repeat(1000);
+    const result = prepareReviewComment(
+      `# PR Review Report\n\n## Risk\nCritical\n\n${critical}\n${low}`,
+    );
+
+    expect(result.truncated).toBe(true);
+    expect(result.body.length).toBeLessThanOrEqual(MAX_REVIEW_COMMENT_CHARACTERS);
+    expect(result.body).toContain('CRITICAL');
+    expect(result.body).toContain('shortened because the complete review exceeded');
+  });
+});

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  OSS_PR_REVIEWER_MARKER,
-  findReviewComment,
-  publishReviewComment,
-} from '../src/github/comments.js';
+import { findReviewComment, publishReviewComment } from '../src/github/comments.js';
+import { OSS_PR_REVIEWER_MARKER } from '../src/github/comment-constants.js';
+import { MAX_REVIEW_COMMENT_CHARACTERS } from '../src/github/comment-safety.js';
 import type { RepositoryReference } from '../src/github/types.js';
 
 const reference: RepositoryReference = { owner: 'octo', repository: 'project' };
@@ -101,5 +99,21 @@ describe('PR comment publishing', () => {
     };
 
     await expect(findReviewComment(client, reference, 7)).rejects.toThrow(/comment API access/);
+  });
+
+  it('publishes a bounded, mention-safe comment body', async () => {
+    const client = {
+      listComments: vi.fn().mockResolvedValue([]),
+      createComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
+      updateComment: vi.fn(),
+    };
+    const report = `# PR Review Report\n\n### CRITICAL - Security\n${'@maintainer critical '.repeat(4000)}`;
+
+    await publishReviewComment(client, reference, 7, report);
+
+    const body = client.createComment.mock.calls[0][2] as string;
+    expect(body.length).toBeLessThanOrEqual(MAX_REVIEW_COMMENT_CHARACTERS);
+    expect(body).toContain('@\u200bmaintainer');
+    expect(body).toContain('shortened because the complete review exceeded');
   });
 });


### PR DESCRIPTION
## Summary
- Add a centralized 60,000-character PR comment limit.
- Preserve report header and prioritize critical/high content when shortening oversized comments.
- Add a clear truncation notice pointing to the complete job summary.
- Neutralize mention-like text with a zero-width guard to avoid notification spam.
- Keep the full report in `GITHUB_STEP_SUMMARY` through the existing summary-first Action flow.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 73 tests
- `npm run build`
- `npm run format:check`
- `git diff --check`

## Security
- No new GitHub permissions or workflow triggers.
- Stable marker is split into a constants module to avoid import cycles.
- Truncation is deterministic and does not execute or interpret reviewed content.
- Mention-like strings from untrusted report content are neutralized.

## Limitations
- Comment mode remains opt-in and summary mode remains the default.
- Live GitHub comment API testing remains pending; tests use deterministic mocks.
