### PR TITLE
docs: document PR comment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The file is loaded from the pull request's base commit, not the PR branch, so a 
 
 ## GitHub Actions
 
-v0.3.0 adds an opt-in composite Action for `pull_request` events. It reuses the CLI, reads the trusted base-branch configuration, and appends the Markdown report to the job summary. It does not post comments or execute the reviewed PR.
+v0.4.0 adds an opt-in composite Action for `pull_request` events. It reuses the CLI, reads the trusted base-branch configuration, and always appends the Markdown report to the job summary. With `post-comment: true`, it also creates or updates one owned PR comment without posting duplicates.
 
 ```yaml
 name: AI PR Review
@@ -123,13 +123,14 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: vuphongle/oss-pr-reviewer@v0.3.0
+      - uses: vuphongle/oss-pr-reviewer@v0.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          post-comment: true
 ```
 
-Live Action reviews require `OPENAI_API_KEY`; tests and local development do not. Fork pull requests normally cannot access repository secrets under `pull_request`, so do not switch to `pull_request_target` casually. See [docs/github-actions.md](docs/github-actions.md) for permissions, inputs, security boundaries, and limitations.
+Comment mode requires `pull-requests: write`; summary-only mode needs only `pull-requests: read`. Live Action reviews require `OPENAI_API_KEY`; tests and local development do not. Fork pull requests normally cannot access repository secrets under `pull_request`, so do not switch to `pull_request_target` casually. See [docs/github-actions.md](docs/github-actions.md) for both workflow examples, permissions, inputs, security boundaries, and limitations.
 
 ## CLI Usage
 
@@ -187,7 +188,7 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 - The tool reviews supplied pull request metadata and patches rather than the full repository.
 - GitHub-truncated, missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
 - Context budgeting uses character approximations rather than exact model tokenization.
-- The GitHub Action does not post comments or create annotations; it writes a job summary only. The CLI does not clone repositories or run tests.
+- The GitHub Action does not create annotations or enforce a merge policy. Comment mode is bounded and advisory; the CLI does not clone repositories or run tests.
 - Live API usage requires network access and valid credentials; automated tests use mocks.
 
 ## Development and Testing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,7 @@ Only the latest release line is actively supported. Security fixes may be backpo
 - The CLI never executes changed code or arbitrary shell commands from a pull request.
 - The reusable Action is intended for the `pull_request` event with least-privilege `contents: read` and `pull-requests: read` permissions. It does not use `pull_request_target`, which has a different trust model and can expose secrets to untrusted workflow context.
 - GitHub does not expose repository secrets to workflows triggered by pull requests from forks. Fork reviews therefore need an explicit maintainer-approved credential strategy; the Action does not bypass this restriction.
-- The Action runs the trusted Action checkout only. It does not check out or execute the contributor's pull request, and it appends the Markdown report to `GITHUB_STEP_SUMMARY` rather than posting comments by default.
+- The Action runs the trusted Action checkout only. It does not check out or execute the contributor's pull request. It always appends the full Markdown report to `GITHUB_STEP_SUMMARY`; optional comment mode requires explicit workflow input and `pull-requests: write`.
+- Comment updates require the stable `<!-- oss-pr-reviewer -->` marker and an expected bot author. Unrelated user comments are not modified, older duplicate tool comments are not deleted, and comment bodies are bounded and mention-neutralized before publishing.
 - Reports may contain code-derived text, so review output before sharing it outside the intended maintainer context.
 - Provider and GitHub errors are normalized without intentionally printing credentials.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,9 @@ Finding merge / deduplicate / filter
   |
 Markdown renderer
   |
-GITHUB_STEP_SUMMARY
+  +--> GITHUB_STEP_SUMMARY (always)
+  |
+  +--> Optional PR comment adapter (create/update)
 ```
 
 ## Boundaries
@@ -48,9 +50,10 @@ GITHUB_STEP_SUMMARY
 - `src/report/` renders the final report without making claims that automated review is definitive.
 - `action.yml` is a thin composite Action. It builds and runs only the trusted Action checkout, parses supported pull request event metadata, and appends the existing Markdown report to the job summary.
 - `src/action/` contains testable Action-boundary code for event parsing, input validation, secret redaction, fork limitations, and summary output. It does not duplicate review logic.
+- `src/github/comments.ts` owns marker-based comment discovery and create/update behavior. `src/github/comment-safety.ts` bounds and sanitizes comment output without changing the full summary report.
 
 Custom rule descriptions are passed as untrusted user-context guidance. They cannot replace or modify the system review policy.
 
 The review prompt labels all pull request content as untrusted data. No changed code is executed, and no repository content outside the supplied pull request is sent to the provider.
 
-The documented workflow uses `pull_request`, read-only permissions, and a tagged Action release. Fork pull requests normally cannot receive repository secrets; the Action does not use `pull_request_target` as a workaround.
+The documented workflows use `pull_request` and tagged Action releases. Summary-only mode uses read permissions; comment mode explicitly adds `pull-requests: write`. Fork pull requests normally cannot receive repository secrets; the Action does not use `pull_request_target` as a workaround.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,6 +1,6 @@
 # GitHub Actions
 
-`oss-pr-reviewer` v0.3.0 includes an opt-in composite GitHub Action for advisory pull request reviews. It reuses the existing CLI and review engine, then appends the generated Markdown report to the workflow job summary through `GITHUB_STEP_SUMMARY`.
+`oss-pr-reviewer` v0.4.0 includes an opt-in composite GitHub Action for advisory pull request reviews. It reuses the existing CLI and review engine, then appends the generated Markdown report to the workflow job summary through `GITHUB_STEP_SUMMARY`. Comment publishing is separately opt-in.
 
 ## Enable the Action
 
@@ -29,6 +29,33 @@ jobs:
 
 The example uses the tagged release rather than `main`. Pin the Action to a reviewed release or commit according to your repository's dependency policy.
 
+## Choose an Output Mode
+
+Summary-only mode is the default and needs only read permissions:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+```
+
+It never writes to the pull request. To opt in to an update-in-place pull request comment, use [examples/github-actions/comment.yml](../examples/github-actions/comment.yml):
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+steps:
+  - uses: vuphongle/oss-pr-reviewer@v0.4.0
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+      post-comment: true
+```
+
+`post-comment` accepts only `true` or `false` and defaults to `false`. Comment mode creates one tool-owned comment on the first run and updates it on later `synchronize` runs. It uses the invisible marker `<!-- oss-pr-reviewer -->`, only targets expected bot-authored comments, and does not delete older duplicates.
+
 ## Inputs
 
 | Input            | Required | Default                    | Purpose                                                                         |
@@ -37,8 +64,9 @@ The example uses the tagged release rather than `main`. Pin the Action to a revi
 | `openai-api-key` | yes      | none                       | Key used for the OpenAI review request.                                         |
 | `model`          | no       | `gpt-4o-mini`              | OpenAI model name.                                                              |
 | `min-severity`   | no       | repository config or `low` | Finding threshold. CLI/Action input overrides repository configuration.         |
+| `post-comment`   | no       | `false`                    | Create or update the owned PR comment. Requires `pull-requests: write`.         |
 
-The Action is advisory. A high or critical finding does not fail the job; configuration, API, or runtime failures do.
+The Action is advisory. A high or critical finding does not fail the job; configuration, API, or runtime failures do. If explicitly enabled comment publishing fails, the Action reports the error and exits non-zero after writing the complete job summary.
 
 ## Permissions and Secrets
 
@@ -50,7 +78,7 @@ permissions:
   pull-requests: read
 ```
 
-Store `OPENAI_API_KEY` as a repository or organization secret. The Action does not print secrets, place them in reports, or post PR comments. It does not request write permissions.
+Store `OPENAI_API_KEY` as a repository or organization secret. The Action does not print secrets or place them in reports. Summary-only mode does not request write permissions; comment mode requires only `pull-requests: write` in addition to `contents: read`.
 
 The Action does not use `pull_request_target`. It runs the trusted Action checkout and does not check out or execute the reviewed contributor branch.
 
@@ -66,4 +94,11 @@ The existing `.oss-pr-reviewer.yml` is loaded from the pull request base commit.
 
 ## Output and Limitations
 
-The report is appended to the Actions job summary. The Action does not post or update PR comments, create annotations, or enforce a merge policy. Live GitHub/OpenAI credentials are not needed for repository tests, but a real Action run requires valid secrets and network access.
+The full report is always appended to the Actions job summary. Comment mode reuses the report, applies a 60,000-character safety limit, preserves higher-priority findings when shortening, neutralizes mention-like text, and adds a truncation notice when needed. It does not create annotations or enforce a merge policy. Live GitHub/OpenAI credentials are not needed for repository tests, but a real Action run requires valid secrets and network access.
+
+## Troubleshooting
+
+- **Permission denied:** add `pull-requests: write` only when `post-comment: true`; keep `pull-requests: read` for summary-only mode.
+- **Fork pull request:** GitHub normally withholds repository secrets from `pull_request` workflows triggered by forks. Do not switch to `pull_request_target` as a workaround.
+- **Comment not created:** check that `post-comment` is exactly `true`, the token is available, and the workflow runs in the repository context with the documented permission.
+- **Shortened comment:** the complete report remains in the job summary; the PR comment is bounded for GitHub's practical comment limits.

--- a/examples/github-actions/comment.yml
+++ b/examples/github-actions/comment.yml
@@ -1,0 +1,20 @@
+name: AI PR Review With Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run oss-pr-reviewer with PR comment output
+        uses: vuphongle/oss-pr-reviewer@v0.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          post-comment: true

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -172,6 +172,18 @@ describe('GitHub Action security documentation', () => {
     expect(workflow).not.toMatch(/pull_request_target/);
   });
 
+  it('documents explicit write permission for opt-in comment mode', async () => {
+    const workflow = await readTextFile(
+      new URL('../examples/github-actions/comment.yml', import.meta.url),
+      'utf8',
+    );
+    expect(workflow).toMatch(/pull_request:/);
+    expect(workflow).toMatch(/pull-requests: write/);
+    expect(workflow).toMatch(/post-comment: true/);
+    expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.4\.0/);
+    expect(workflow).not.toMatch(/pull_request_target/);
+  });
+
   it('declares opt-in comment mode and stable outputs in action.yml', async () => {
     const action = await readTextFile(new URL('../action.yml', import.meta.url), 'utf8');
     expect(action).toMatch(/post-comment:/);


### PR DESCRIPTION
## Summary
- Document summary-only versus opt-in PR comment workflows and their least-privilege permissions.
- Add `examples/github-actions/comment.yml` with `pull-requests: write` and `post-comment: true`.
- Document stable marker ownership, idempotent updates, truncation, mention safety, fork limitations, and troubleshooting.
- Update README, architecture, and security documentation.

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 74 tests
- `npm run build`
- `npm run format:check`
- YAML parse checks for `action.yml`, basic workflow, and comment workflow
- `git diff --check`

## Security
- Summary mode remains read-only and default.
- Comment mode is explicit and documents only `pull-requests: write` in addition to `contents: read`.
- Documentation keeps `pull_request`, rejects `pull_request_target` workarounds, and explains fork secret limitations.
- Comment targeting, marker ownership, mention neutralization, and size limits are documented.

## Limitations
- Version examples use `@v0.4.0` and will become active when the release tag is published.
- Live GitHub/OpenAI comment smoke testing remains pending.
