### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.0
+
+- Added opt-in GitHub Action PR comment output through `post-comment: true`; summary output remains the default.
+- Added stable marker-based comment ownership with create-once and update-in-place behavior for repeated reviews.
+- Added `comment-action`, `comment-id`, and `comment-url` Action outputs.
+- Added least-privilege documentation for summary-only (`pull-requests: read`) and comment mode (`pull-requests: write`).
+- Added deterministic comment-size limiting, priority-aware truncation, mention neutralization, fork guidance, and troubleshooting docs.
+
+Comment mode does not use `pull_request_target`, execute reviewed code, delete old comments, or fail because findings are high or critical. Live GitHub/OpenAI PR comment smoke testing remains pending; validation uses deterministic mocks, synthetic events, static Action checks, and CI.
+
 ## 0.3.0
 
 - Added an opt-in composite GitHub Action for `pull_request` events with `opened`, `synchronize`, and `reopened` actions.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install
 npm run build
 ```
 
-The v0.3.0 release is package-ready but is not published to npm by this repository yet. Run the CLI from the checkout with `node dist/cli/index.js`, or use `npm link` for a local global command:
+The v0.4.0 release is package-ready but is not published to npm by this repository yet. Run the CLI from the checkout with `node dist/cli/index.js`, or use `npm link` for a local global command:
 
 ```bash
 npm link

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oss-pr-reviewer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oss-pr-reviewer",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-pr-reviewer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI-powered CLI for reviewing GitHub pull requests, detecting potential bugs, security risks, regressions, and missing tests, with structured Markdown reports for open-source maintainers.",
   "type": "module",
   "bin": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,7 +13,7 @@ const program = new Command()
   .description(
     'AI-powered CLI for reviewing GitHub pull requests with structured Markdown reports.',
   )
-  .version('0.3.0');
+  .version('0.4.0');
 
 program
   .command('review')

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -11,7 +11,7 @@ describe('CLI input parsing', () => {
     const packageJson = JSON.parse(
       await readFile(new URL('../package.json', import.meta.url), 'utf8'),
     ) as { version: string };
-    expect(packageJson.version).toBe('0.3.0');
+    expect(packageJson.version).toBe('0.4.0');
   });
   it('parses owner/repository', () =>
     expect(parseRepository('octo/project')).toEqual({ owner: 'octo', repository: 'project' }));


### PR DESCRIPTION
## Summary
- Bump package and CLI metadata to `0.4.0`.
- Add the v0.4.0 changelog entry for opt-in idempotent PR comments.
- Document the released comment mode, safety limits, permissions, and limitations.

## Features included
- Summary output remains default and always receives the full report.
- `post-comment: true` creates or updates one owned PR comment.
- Stable marker and bot ownership checks prevent unrelated comment edits.
- Comment output is bounded, priority-aware, and mention-safe.
- Action outputs expose comment action, ID, and URL.

## Testing
- `npm install` — PASS, 0 vulnerabilities
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run test` — PASS, 74 tests
- `npm run build` — PASS
- `npm run format:check` — PASS
- YAML validation — PASS
- CLI version/help — PASS
- `npm pack --dry-run` — PASS
- secret scan — PASS
- `git diff --check` — PASS

## Security
- Summary mode uses read permissions; comment mode documents only `pull-requests: write`.
- `pull_request_target` is not used.
- Reviewed PR code is not checked out or executed.
- Comment targeting requires stable marker and expected bot identity.
- Full report remains in the job summary when comment output is shortened.

## Live integration
Live GitHub/OpenAI PR comment smoke testing remains pending because credentials were not used in CI.
