### PR TITLE
docs: align v0.4 usage references

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ OPENAI_API_KEY=
 
 ### Repository configuration
 
-v0.2 supports an optional `.oss-pr-reviewer.yml` file:
+`oss-pr-reviewer` supports an optional `.oss-pr-reviewer.yml` file:
 
 ```yaml
 version: 1
@@ -127,7 +127,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          post-comment: true
 ```
 
 Comment mode requires `pull-requests: write`; summary-only mode needs only `pull-requests: read`. Live Action reviews require `OPENAI_API_KEY`; tests and local development do not. Fork pull requests normally cannot access repository secrets under `pull_request`, so do not switch to `pull_request_target` casually. See [docs/github-actions.md](docs/github-actions.md) for both workflow examples, permissions, inputs, security boundaries, and limitations.
@@ -172,7 +171,7 @@ The full report also includes pull request metadata, summary, statistics, skippe
 
 ## Architecture
 
-The CLI depends on a small `ReviewProvider` interface, so the review engine does not contain OpenAI SDK details. v0.3.0 ships one provider: OpenAI. Review content, repository rules, and ignored-path configuration are treated as untrusted repository data; changed code is never executed. See [docs/architecture.md](docs/architecture.md).
+The CLI depends on a small `ReviewProvider` interface, so the review engine does not contain OpenAI SDK details. The current release ships one provider: OpenAI. Review content, repository rules, and ignored-path configuration are treated as untrusted repository data; changed code is never executed. See [docs/architecture.md](docs/architecture.md).
 
 ## Review Philosophy
 
@@ -184,7 +183,7 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 
 ## Limitations
 
-- Only OpenAI is implemented in v0.3.0.
+- Only OpenAI is implemented as a provider.
 - The tool reviews supplied pull request metadata and patches rather than the full repository.
 - GitHub-truncated, missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
 - Context budgeting uses character approximations rather than exact model tokenization.
@@ -205,9 +204,7 @@ Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md). CI runs the same
 
 ## Roadmap
 
-These are possible future directions, not current features:
-
-- **v0.4:** optional PR comments or annotations, subject to a separate permission and duplicate-output design.
+Possible future directions include GitHub annotations and other maintainer-focused improvements informed by real-world usage.
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Repository Configuration
 
-v0.3.0 supports the optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes. The same behavior is used by the GitHub Action.
+`oss-pr-reviewer` supports the optional `.oss-pr-reviewer.yml` file at the repository root. Configuration is read from the pull request's trusted base commit, not from the pull request head. This prevents a pull request from changing the review policy used to inspect its own changes. The same behavior is used by the GitHub Action.
 
 ## Example
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -21,7 +21,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: vuphongle/oss-pr-reviewer@v0.3.0
+      - uses: vuphongle/oss-pr-reviewer@v0.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/review-format.md
+++ b/docs/review-format.md
@@ -1,6 +1,6 @@
 # Review Format
 
-The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. v0.3.0 keeps the v0.2.0 statistics, including files changed, files ignored by configuration, and review batches. The GitHub Action places the same report in the Actions job summary.
+The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. The report includes statistics such as files changed, files ignored by configuration, and review batches. The GitHub Action places the same report in the Actions job summary.
 
 ## Severity
 

--- a/examples/github-actions/basic.yml
+++ b/examples/github-actions/basic.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run oss-pr-reviewer
-        uses: vuphongle/oss-pr-reviewer@v0.3.0
+        uses: vuphongle/oss-pr-reviewer@v0.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -168,7 +168,7 @@ describe('GitHub Action security documentation', () => {
     expect(workflow).toMatch(/pull_request:/);
     expect(workflow).toMatch(/contents: read/);
     expect(workflow).toMatch(/pull-requests: read/);
-    expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.3\.0/);
+    expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.4\.0/);
     expect(workflow).not.toMatch(/pull_request_target/);
   });
 


### PR DESCRIPTION
## Summary

- update current documentation and workflow examples to v0.4.0
- make the README Action example summary-only unless write permission is explicitly added
- update the coupled documentation assertion

## Validation

- npm ci (0 vulnerabilities)
- npm run lint
- npm run typecheck
- npm run test (74 passed)
- npm run build
- npm run format:check
- npm pack --dry-run
- CLI help/version, YAML metadata/path checks, secret-pattern scan
- fresh clone of tagged v0.4.0 validated independently

No live GitHub/OpenAI review was run.