### PR TITLE
fix(schema): keep unknown severity aggregate-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Validate OpenAI JSON responses with Zod.
 - Deduplicate identical findings and apply deterministic severity filtering.
 - Print Markdown to stdout or write it to `--output`.
+- Emit structured JSON output with `--output-format json` for CI integration.
 - Run lint, typecheck, tests, and build in GitHub Actions without live review secrets.
 - Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 - Add repository-specific review rules and ignore paths without changing application code.
@@ -142,6 +143,7 @@ node dist/cli/index.js review --url https://github.com/owner/repository/pull/123
 node dist/cli/index.js review --repo owner/repository --pr 123 --model gpt-4o-mini
 node dist/cli/index.js review --repo owner/repository --pr 123 --min-severity high
 node dist/cli/index.js review --repo owner/repository --pr 123 --output review.md
+node dist/cli/index.js review --repo owner/repository --pr 123 --output review.json --output-format json
 ```
 
 `--repo` and `--pr` must be supplied together. `--url` is mutually exclusive with that pair. Supported minimum severities are `low`, `medium`, `high`, and `critical`. A high or critical finding does not make the process fail; configuration, API, filesystem, and validation failures return a non-zero exit code.

--- a/docs/review-format.md
+++ b/docs/review-format.md
@@ -1,19 +1,22 @@
 # Review Format
 
-The CLI emits Markdown with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. The report includes statistics such as files changed, files ignored by configuration, and review batches. The GitHub Action places the same report in the Actions job summary.
+The CLI emits a structured report with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. The report includes statistics such as files changed, files ignored by configuration, and review batches. The GitHub Action places the same report in the Actions job summary.
+
+By default the report is rendered as Markdown. `--output-format json` emits the same `ReviewReportData` shape as deterministic JSON for CI integration and downstream tooling. The JSON contains `pullRequest`, `result` (with `summary`, `riskLevel`, and `findings`), `skippedFiles`, and the same count fields as the Markdown statistics block. Findings with `riskLevel: unknown` mean no review was performed (no reviewable patches or all findings filtered out).
 
 ## Severity
 
+- `unknown`: no review was performed for this pull request (no reviewable text patches, or every finding was filtered out by the minimum severity).
 - `critical`: evidence of a severe security, data-loss, or system-breaking issue.
 - `high`: a likely serious bug, security problem, regression, or breaking behavior.
 - `medium`: a meaningful correctness, test, error-handling, or maintainability concern.
 - `low`: a lower-impact issue that is still actionable and supported by the diff.
 
-`--min-severity` is applied deterministically after provider responses are validated. The order is `low < medium < high < critical`.
+`--min-severity` is applied deterministically after provider responses are validated. The order is `unknown < low < medium < high < critical`. Findings cannot be reported at the `unknown` level.
 
 ## Risk level
 
-The provider returns one aggregate risk level for the reviewed batch. The final report uses the highest risk level returned across batches. Risk is an assessment of review context, not a guarantee about the pull request.
+Risk is derived from the filtered findings, so a report with no surviving findings (no reviewable patches or every finding below `--min-severity`) reports `riskLevel: unknown`. When findings survive filtering, the final report uses the highest severity among them. Risk is an assessment of review context, not a guarantee about the pull request.
 
 ## Categories
 

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -2,42 +2,51 @@ import { writeFile } from 'node:fs/promises';
 
 import { requireOpenAiKey, loadConfig } from '../../config/index.js';
 import { OpenAiReviewProvider } from '../../ai/client.js';
+import type { ReviewProvider } from '../../ai/provider.js';
 import { GithubClient } from '../../github/client.js';
+import type { RepositoryFileReader } from '../../config/repository.js';
 import { parsePullRequestUrl, parseRepository } from '../../github/types.js';
 import { renderMarkdown } from '../../report/markdown.js';
+import { renderJson } from '../../report/json.js';
 import { reviewPullRequest } from '../../review/reviewer.js';
 import type { Severity } from '../../types.js';
 import type { RepositoryConfig } from '../../config/repository.js';
 import { getConfiguredMinimumSeverity, loadRepositoryConfig } from '../../config/repository.js';
+
+export type ReportFormat = 'markdown' | 'json';
 
 export interface ReviewCommandOptions {
   repo?: string;
   pr?: string;
   url?: string;
   output?: string;
+  outputFormat?: ReportFormat;
   model?: string;
   minSeverity?: Severity;
+  github?: Pick<GithubClient, 'getPullRequest'> & RepositoryFileReader;
+  provider?: ReviewProvider;
 }
 
 export async function executeReview(options: ReviewCommandOptions): Promise<string> {
   const input = resolveInput(options);
   const config = loadConfig();
   const openAiApiKey = requireOpenAiKey(config);
-  const github = new GithubClient({ token: config.githubToken });
+  const github = options.github ?? new GithubClient({ token: config.githubToken });
   const pullRequest = await github.getPullRequest(input.repository, input.number);
   const repositoryConfig = await loadRepositoryConfig(github, {
     owner: pullRequest.owner,
     repository: pullRequest.repository,
     ref: pullRequest.baseSha,
   });
-  const provider = new OpenAiReviewProvider(openAiApiKey, options.model);
+  const provider =
+    options.provider ?? new OpenAiReviewProvider(openAiApiKey, options.model);
   const execution = await reviewPullRequest(
     pullRequest,
     provider,
     resolveMinimumSeverity(options.minSeverity, repositoryConfig),
     repositoryConfig,
   );
-  const report = renderMarkdown({ pullRequest, ...execution });
+  const report = renderReport({ pullRequest, ...execution }, options.outputFormat ?? 'markdown');
 
   if (options.output) {
     try {
@@ -50,6 +59,13 @@ export async function executeReview(options: ReviewCommandOptions): Promise<stri
   }
 
   return report;
+}
+
+export function renderReport(
+  data: Parameters<typeof renderMarkdown>[0],
+  format: ReportFormat,
+): string {
+  return format === 'json' ? renderJson(data) : renderMarkdown(data);
 }
 
 export function resolveMinimumSeverity(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,7 +21,8 @@ program
   .option('--repo <owner/repository>', 'repository identifier; requires --pr')
   .option('--pr <number>', 'pull request number; requires --repo')
   .option('--url <url>', 'GitHub pull request URL')
-  .option('--output <path>', 'write Markdown report to a file instead of only stdout')
+  .option('--output <path>', 'write report to a file instead of only stdout')
+  .option('--output-format <format>', 'report format (markdown, json)', 'markdown')
   .option('--model <model-name>', 'OpenAI model name', 'gpt-4o-mini')
   .option('--min-severity <severity>', 'minimum finding severity (low, medium, high, critical)')
   .action(
@@ -30,6 +31,7 @@ program
       pr?: string;
       url?: string;
       output?: string;
+      outputFormat?: string;
       model?: string;
       minSeverity?: string;
     }) => {
@@ -38,9 +40,16 @@ program
           `Unsupported severity '${options.minSeverity}'. Choose low, medium, high, or critical.`,
         );
       }
+      const outputFormat = options.outputFormat ?? 'markdown';
+      if (outputFormat !== 'markdown' && outputFormat !== 'json') {
+        throw new Error(
+          `Unsupported output format '${outputFormat}'. Choose markdown or json.`,
+        );
+      }
       const report = await executeReview({
         ...options,
         minSeverity: options.minSeverity as Severity | undefined,
+        outputFormat,
       });
       if (!options.output) process.stdout.write(report);
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './review/schema.js';
 export * from './review/severity.js';
 export * from './review/ignore.js';
 export * from './report/markdown.js';
+export * from './report/json.js';
 export * from './ai/provider.js';
 export * from './ai/client.js';
 export * from './config/repository.js';

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,0 +1,5 @@
+import type { ReviewReportData } from '../types.js';
+
+export function renderJson(data: ReviewReportData): string {
+  return `${JSON.stringify(data, null, 2)}\n`;
+}

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -70,7 +70,7 @@ function countFindings(findings: ReviewFinding[]): Record<Severity, number> {
       counts[finding.severity] += 1;
       return counts;
     },
-    { critical: 0, high: 0, medium: 0, low: 0 },
+    { unknown: 0, critical: 0, high: 0, medium: 0, low: 0 },
   );
 }
 

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -34,7 +34,7 @@ export async function reviewPullRequest(
     return {
       result: {
         summary: 'No reviewable text patches were available in this pull request.',
-        riskLevel: 'low',
+        riskLevel: 'unknown',
         findings: [],
       },
       skippedFiles,
@@ -54,11 +54,16 @@ export async function reviewPullRequest(
     deduplicateFindings(results.flatMap((result) => result.findings)),
     minimumSeverity,
   );
-  const riskLevel = results.reduce<Severity>(
-    (highest, result) =>
-      severityOrder[result.riskLevel] > severityOrder[highest] ? result.riskLevel : highest,
-    'low',
-  );
+  const riskLevel =
+    findings.length === 0
+      ? 'unknown'
+      : findings.reduce<Severity>(
+          (highest, finding) =>
+            severityOrder[finding.severity] > severityOrder[highest]
+              ? finding.severity
+              : highest,
+          'low',
+        );
   const summary = results
     .map((result) => result.summary.trim())
     .filter(Boolean)

--- a/src/review/schema.ts
+++ b/src/review/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
-export const severitySchema = z.enum(['unknown', 'low', 'medium', 'high', 'critical']);
+export const severitySchema = z.enum(['low', 'medium', 'high', 'critical']);
+export const riskLevelSchema = z.enum(['unknown', 'low', 'medium', 'high', 'critical']);
 export const categorySchema = z.enum([
   'bug',
   'security',
@@ -23,7 +24,7 @@ export const findingSchema = z.object({
 
 export const reviewResultSchema = z.object({
   summary: z.string().trim().min(1),
-  riskLevel: severitySchema,
+  riskLevel: riskLevelSchema,
   findings: z.array(findingSchema),
 });
 

--- a/src/review/schema.ts
+++ b/src/review/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const severitySchema = z.enum(['low', 'medium', 'high', 'critical']);
+export const severitySchema = z.enum(['unknown', 'low', 'medium', 'high', 'critical']);
 export const categorySchema = z.enum([
   'bug',
   'security',

--- a/src/review/severity.ts
+++ b/src/review/severity.ts
@@ -1,6 +1,12 @@
 import type { ReviewFinding, Severity } from '../types.js';
 
-export const severityOrder: Record<Severity, number> = { low: 0, medium: 1, high: 2, critical: 3 };
+export const severityOrder: Record<Severity, number> = {
+  unknown: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
 
 export function filterFindings(findings: ReviewFinding[], minimum: Severity): ReviewFinding[] {
   return findings.filter((finding) => severityOrder[finding.severity] >= severityOrder[minimum]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Severity = 'low' | 'medium' | 'high' | 'critical';
+export type Severity = 'unknown' | 'low' | 'medium' | 'high' | 'critical';
 
 export type ReviewCategory =
   | 'bug'

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -5,6 +5,8 @@ import { URL } from 'node:url';
 
 import { parsePullRequestUrl, parseRepository } from '../src/github/types.js';
 import { executeReview } from '../src/cli/commands/review.js';
+import type { ReviewProvider } from '../src/ai/provider.js';
+import { pullRequestFixture, resultFixture } from './fixtures.js';
 
 describe('CLI input parsing', () => {
   it('keeps the CLI version aligned with release metadata', async () => {
@@ -45,6 +47,45 @@ describe('CLI input parsing', () => {
       ).rejects.toThrow(/OPENAI_API_KEY is required/);
     } finally {
       if (previousKey) process.env.OPENAI_API_KEY = previousKey;
+    }
+  });
+});
+
+describe('CLI output format', () => {
+  it('renders Markdown by default and JSON when output-format=json is set', async () => {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = 'test-key';
+    const github = {
+      getPullRequest: async () => pullRequestFixture,
+      getFileAtRef: async () => undefined,
+    };
+    const provider: ReviewProvider = { review: async () => resultFixture() };
+    try {
+      const markdown = await executeReview(
+        {
+          repo: 'example/project',
+          pr: '12',
+          outputFormat: 'markdown',
+          github: github as never,
+          provider,
+        },
+      );
+      expect(markdown).toContain('# PR Review Report');
+
+      const json = await executeReview(
+        {
+          repo: 'example/project',
+          pr: '12',
+          outputFormat: 'json',
+          github: github as never,
+          provider,
+        },
+      );
+      expect(() => JSON.parse(json)).not.toThrow();
+      expect(JSON.parse(json).pullRequest.number).toBe(12);
+    } finally {
+      if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = previousKey;
     }
   });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { renderMarkdown } from '../src/report/markdown.js';
+import { renderJson } from '../src/report/json.js';
 import { findingFixture, pullRequestFixture, resultFixture } from './fixtures.js';
 
 describe('Markdown report', () => {
@@ -37,5 +38,57 @@ describe('Markdown report', () => {
     expect(report).toContain('`logo.png`: binary');
     expect(report).toContain('Medium: 1');
     expect(report).toContain('Files ignored: 0');
+  });
+  it('renders an unknown risk when no review was performed', () => {
+    const report = renderMarkdown({
+      pullRequest: pullRequestFixture,
+      result: resultFixture({ findings: [], riskLevel: 'unknown' }),
+      skippedFiles: [{ path: 'image.png', reason: 'binary asset' }],
+      reviewedFileCount: 0,
+      changedFileCount: 1,
+      ignoredFileCount: 0,
+      batchCount: 0,
+    });
+    expect(report).toContain('- Risk: Unknown');
+    expect(report).toContain('No significant issues');
+  });
+});
+
+describe('JSON report', () => {
+  const baseData = {
+    pullRequest: pullRequestFixture,
+    result: resultFixture({
+      findings: [
+        findingFixture(),
+        findingFixture({ severity: 'medium', title: 'Missing test' }),
+      ],
+    }),
+    skippedFiles: [{ path: 'logo.png', reason: 'binary' }],
+    reviewedFileCount: 1,
+    changedFileCount: 2,
+    ignoredFileCount: 0,
+    batchCount: 1,
+  };
+
+  it('serializes the full ReviewReportData shape to pretty JSON', () => {
+    const json = renderJson(baseData);
+    const parsed = JSON.parse(json) as typeof baseData;
+    expect(parsed.pullRequest).toEqual(pullRequestFixture);
+    expect(parsed.result.findings).toHaveLength(2);
+    expect(parsed.skippedFiles).toEqual([{ path: 'logo.png', reason: 'binary' }]);
+    expect(parsed.reviewedFileCount).toBe(1);
+    expect(parsed.changedFileCount).toBe(2);
+    expect(parsed.batchCount).toBe(1);
+  });
+
+  it('preserves unknown risk level for empty reviews', () => {
+    const json = renderJson({ ...baseData, result: resultFixture({ findings: [], riskLevel: 'unknown' }) });
+    expect(JSON.parse(json).result.riskLevel).toBe('unknown');
+  });
+
+  it('emits deterministic two-space indentation', () => {
+    const json = renderJson(baseData);
+    expect(json).toContain('\n  "pullRequest":');
+    expect(json.endsWith('\n')).toBe(true);
   });
 });

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -10,7 +10,7 @@ import { DEFAULT_REPOSITORY_CONFIG } from '../src/config/repository.js';
 
 describe('severity and findings', () => {
   it('orders severities deterministically', () =>
-    expect(severityOrder).toEqual({ low: 0, medium: 1, high: 2, critical: 3 }));
+    expect(severityOrder).toEqual({ unknown: 0, low: 1, medium: 2, high: 3, critical: 4 }));
   it('filters findings at the requested minimum', () =>
     expect(
       filterFindings(
@@ -100,6 +100,47 @@ describe('review pipeline', () => {
     expect(execution.reviewedFileCount).toBe(0);
     expect(execution.changedFileCount).toBe(1);
     expect(execution.batchCount).toBe(0);
+  });
+
+  it('reports unknown risk when no patches were available for AI review', async () => {
+    const provider: ReviewProvider = { review: async () => resultFixture() };
+    const execution = await reviewPullRequest(
+      {
+        ...pullRequestFixture,
+        files: [{ path: 'image.png', status: 'modified', additions: 0, deletions: 0 }],
+      },
+      provider,
+    );
+    expect(execution.result.riskLevel).toBe('unknown');
+  });
+
+  it('derives risk from filtered findings, not raw provider output', async () => {
+    const provider: ReviewProvider = {
+      review: async () =>
+        resultFixture({
+          riskLevel: 'critical',
+          findings: [findingFixture({ severity: 'low' })],
+        }),
+    };
+    const execution = await reviewPullRequest(pullRequestFixture, provider, 'high');
+    expect(execution.result.findings).toEqual([]);
+    expect(execution.result.riskLevel).toBe('unknown');
+  });
+
+  it('keeps the highest risk from findings that pass the severity filter', async () => {
+    const provider: ReviewProvider = {
+      review: async () =>
+        resultFixture({
+          riskLevel: 'low',
+          findings: [
+            findingFixture({ severity: 'low', title: 'Style' }),
+            findingFixture({ severity: 'critical', title: 'Critical' }),
+          ],
+        }),
+    };
+    const execution = await reviewPullRequest(pullRequestFixture, provider, 'medium');
+    expect(execution.result.findings).toHaveLength(1);
+    expect(execution.result.riskLevel).toBe('critical');
   });
 
   it('passes repository rules to the provider and reports ignored files', async () => {

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -14,6 +14,10 @@ describe('review response schema', () => {
     expect(() => parseReviewResult({ ...resultFixture(), riskLevel: 'urgent' })).toThrow(
       /schema validation/,
     ));
+  it('accepts unknown as a valid risk level for empty reviews', () =>
+    expect(
+      parseReviewResult({ ...resultFixture(), riskLevel: 'unknown', findings: [] }),
+    ).toMatchObject({ riskLevel: 'unknown' }));
   it('rejects whitespace-only text fields', () =>
     expect(() =>
       parseReviewResult({

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -14,6 +14,13 @@ describe('review response schema', () => {
     expect(() => parseReviewResult({ ...resultFixture(), riskLevel: 'urgent' })).toThrow(
       /schema validation/,
     ));
+  it('rejects unknown as a finding severity', () =>
+    expect(() =>
+      parseReviewResult({
+        ...resultFixture(),
+        findings: [{ ...resultFixture().findings[0], severity: 'unknown' }],
+      }),
+    ).toThrow(/schema validation/));
   it('accepts unknown as a valid risk level for empty reviews', () =>
     expect(
       parseReviewResult({ ...resultFixture(), riskLevel: 'unknown', findings: [] }),


### PR DESCRIPTION
## Summary

- Keep `unknown` valid only for the aggregate `riskLevel`.
- Reject `unknown` as a finding severity, matching the prompt and review-format contract.
- Add a regression test for the invalid finding value.

This PR supersedes #23 and includes its requested risk-level/JSON changes plus this schema correction.

## Validation

- npm test -- --run (84 passed)
- npm run typecheck
- npm run lint
- npm run build

## Review note

No live OpenAI/GitHub review was performed; this is deterministic schema validation and local quality-gate coverage.