### PR TITLE
feat: retry transient OpenAI and GitHub API failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Deduplicate identical findings and apply deterministic severity filtering.
 - Print Markdown to stdout or write it to `--output`.
 - Emit structured JSON output with `--output-format json` for CI integration.
+- Retry transient OpenAI and GitHub API failures (HTTP 429, 5xx) with exponential backoff.
 - Run lint, typecheck, tests, and build in GitHub Actions without live review secrets.
 - Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 - Add repository-specific review rules and ignore paths without changing application code.

--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -6,13 +6,29 @@ import { buildReviewPrompt, REVIEW_SYSTEM_PROMPT } from '../review/prompt.js';
 import { parseJsonReviewResponse } from '../review/schema.js';
 import type { ReviewProvider } from './provider.js';
 
+export interface OpenAiReviewOptions {
+  maxRetries?: number;
+  backoffMs?: (attempt: number, error: unknown) => number;
+}
+
+const DEFAULT_MAX_RETRIES = 2;
+
 export class OpenAiReviewProvider implements ReviewProvider {
   private readonly client: OpenAI;
   private readonly model: string;
+  private readonly maxRetries: number;
+  private readonly backoffMs: (attempt: number, error: unknown) => number;
 
-  constructor(apiKey: string, model = 'gpt-4o-mini', client?: OpenAI) {
+  constructor(
+    apiKey: string,
+    model = 'gpt-4o-mini',
+    client?: OpenAI,
+    options: OpenAiReviewOptions = {},
+  ) {
     this.client = client ?? new OpenAI({ apiKey });
     this.model = model;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.backoffMs = options.backoffMs ?? exponentialBackoff;
   }
 
   async review(input: {
@@ -20,31 +36,75 @@ export class OpenAiReviewProvider implements ReviewProvider {
     batch: ReviewBatch;
     reviewRules?: import('../config/repository.js').ReviewRule[];
   }): Promise<ReviewResult> {
+    const messages = [
+      { role: 'system' as const, content: REVIEW_SYSTEM_PROMPT },
+      {
+        role: 'user' as const,
+        content: buildReviewPrompt(input.pullRequest, input.batch, input.reviewRules),
+      },
+    ];
+
+    let response;
     try {
-      const response = await this.client.chat.completions.create({
-        model: this.model,
-        temperature: 0,
-        response_format: { type: 'json_object' },
-        messages: [
-          { role: 'system', content: REVIEW_SYSTEM_PROMPT },
-          {
-            role: 'user',
-            content: buildReviewPrompt(input.pullRequest, input.batch, input.reviewRules),
-          },
-        ],
-      });
-      const content = response.choices[0]?.message.content;
-      if (!content) throw new Error('AI review response was empty.');
-      return parseJsonReviewResponse(content);
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('AI review response')) throw error;
-      const candidate = error as { status?: number; message?: string };
-      if (candidate.status === 401)
-        throw new Error('OpenAI authentication failed. Check OPENAI_API_KEY.');
-      if (candidate.status === 429) throw new Error('OpenAI rate limit reached. Retry later.');
-      throw new Error(
-        `OpenAI review request failed${candidate.message ? `: ${candidate.message}` : '.'}`,
+      response = await retry(this.maxRetries, this.backoffMs, () =>
+        this.client.chat.completions.create({
+          model: this.model,
+          temperature: 0,
+          response_format: { type: 'json_object' },
+          messages,
+        }),
       );
+    } catch (error) {
+      throw normalizeOpenAiError(error);
+    }
+
+    const content = response.choices[0]?.message.content;
+    if (!content) throw new Error('AI review response was empty.');
+    return parseJsonReviewResponse(content);
+  }
+}
+
+export function normalizeOpenAiError(error: unknown): Error {
+  if (error instanceof Error && error.message.startsWith('AI review response')) return error;
+  const candidate = error as { status?: number; message?: string };
+  if (candidate.status === 401)
+    return new Error('OpenAI authentication failed. Check OPENAI_API_KEY.');
+  if (candidate.status === 429) return new Error('OpenAI rate limit reached. Retry later.');
+  if (typeof candidate.status === 'number' && candidate.status >= 500)
+    return new Error('OpenAI service is temporarily unavailable. Retry later.');
+  return new Error(
+    `OpenAI review request failed${candidate.message ? `: ${candidate.message}` : '.'}`,
+  );
+}
+
+export async function retry<T>(
+  maxRetries: number,
+  backoffMs: (attempt: number, error: unknown) => number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxRetries || !isRetryable(error)) throw error;
+      await sleep(backoffMs(attempt + 1, error));
     }
   }
+  throw lastError;
+}
+
+export function isRetryable(error: unknown): boolean {
+  const candidate = error as { status?: number };
+  return candidate.status === 429 || (typeof candidate.status === 'number' && candidate.status >= 500);
+}
+
+function exponentialBackoff(attempt: number): number {
+  return Math.min(1000 * 2 ** (attempt - 1), 8000);
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -5,18 +5,33 @@ import type { PullRequest } from '../types.js';
 import type { RepositoryReference } from './types.js';
 import type { RepositoryFileReader } from '../config/repository.js';
 import type { ReviewComment, ReviewCommentClient } from './comments.js';
+import { retry, isRetryable } from '../ai/client.js';
+
+export interface GithubRetryOptions {
+  maxRetries?: number;
+  backoffMs?: (attempt: number, error: unknown) => number;
+}
 
 interface GithubClientOptions {
   token?: string;
   octokit?: Octokit;
+  retry?: GithubRetryOptions;
 }
+
+const DEFAULT_MAX_RETRIES = 2;
+const exponentialBackoff = (attempt: number): number =>
+  Math.min(1000 * 2 ** (attempt - 1), 8000);
 
 export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
   private readonly octokit: Octokit;
+  private readonly maxRetries: number;
+  private readonly backoffMs: (attempt: number, error: unknown) => number;
 
   constructor(options: GithubClientOptions = {}) {
     this.octokit =
       options.octokit ?? new Octokit(options.token ? { auth: options.token } : undefined);
+    this.maxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.backoffMs = options.retry?.backoffMs ?? exponentialBackoff;
   }
 
   async getPullRequest(reference: RepositoryReference, number: number): Promise<PullRequest> {
@@ -62,12 +77,14 @@ export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
     ref: string,
   ): Promise<string | undefined> {
     try {
-      const response = await this.octokit.repos.getContent({
-        owner: reference.owner,
-        repo: reference.repository,
-        path,
-        ref,
-      });
+      const response = await retry(this.maxRetries, this.backoffMs, () =>
+        this.octokit.repos.getContent({
+          owner: reference.owner,
+          repo: reference.repository,
+          path,
+          ref,
+        }),
+      );
       if (!('content' in response.data) || response.data.type !== 'file') return undefined;
       return Buffer.from(response.data.content, 'base64').toString('utf8');
     } catch (error) {
@@ -139,7 +156,7 @@ export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
   }
 }
 
-function normalizeGithubError(error: unknown): Error {
+export function normalizeGithubError(error: unknown): Error {
   const candidate = error as { status?: number; message?: string };
   if (candidate.status === 401)
     return new Error('GitHub authentication failed. Check GITHUB_TOKEN.');
@@ -149,6 +166,8 @@ function normalizeGithubError(error: unknown): Error {
     );
   if (candidate.status === 404)
     return new Error('GitHub pull request was not found or is not accessible.');
+  if (isRetryable(error))
+    return new Error('GitHub service is temporarily unavailable. Retry later.');
   return new Error(
     `GitHub API request failed${candidate.message ? `: ${candidate.message}` : '.'}`,
   );

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -58,10 +58,111 @@ describe('OpenAI provider boundary', () => {
       },
     } as unknown as OpenAI;
     await expect(
-      new OpenAiReviewProvider('secret-key', 'test-model', client).review({
+      new OpenAiReviewProvider('secret-key', 'test-model', client, { maxRetries: 0 }).review({
         pullRequest: pullRequestFixture,
         batch,
       }),
     ).rejects.toThrow(/rate limit/);
+  });
+
+  describe('retry behaviour', () => {
+    it('retries 429 responses up to the configured limit', async () => {
+      const create = vi
+        .fn()
+        .mockRejectedValueOnce({ status: 429, message: 'limit' })
+        .mockResolvedValueOnce({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ summary: 'ok', riskLevel: 'low', findings: [] }),
+              },
+            },
+          ],
+        });
+      const client = {
+        chat: { completions: { create } },
+      } as unknown as OpenAI;
+      const result = await new OpenAiReviewProvider('test-key', 'test-model', client, {
+        maxRetries: 2,
+        backoffMs: () => 0,
+      }).review({ pullRequest: pullRequestFixture, batch });
+      expect(create).toHaveBeenCalledTimes(2);
+      expect(result.riskLevel).toBe('low');
+    });
+
+    it('retries 5xx responses up to the configured limit', async () => {
+      const create = vi
+        .fn()
+        .mockRejectedValueOnce({ status: 503, message: 'unavailable' })
+        .mockResolvedValueOnce({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ summary: 'ok', riskLevel: 'low', findings: [] }),
+              },
+            },
+          ],
+        });
+      const client = {
+        chat: { completions: { create } },
+      } as unknown as OpenAI;
+      await new OpenAiReviewProvider('test-key', 'test-model', client, {
+        maxRetries: 2,
+        backoffMs: () => 0,
+      }).review({ pullRequest: pullRequestFixture, batch });
+      expect(create).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry 4xx responses other than 429', async () => {
+      const create = vi.fn().mockRejectedValue({ status: 401, message: 'auth' });
+      const client = {
+        chat: { completions: { create } },
+      } as unknown as OpenAI;
+      await expect(
+        new OpenAiReviewProvider('test-key', 'test-model', client, {
+          maxRetries: 3,
+          backoffMs: () => 0,
+        }).review({ pullRequest: pullRequestFixture, batch }),
+      ).rejects.toThrow(/authentication/);
+      expect(create).toHaveBeenCalledOnce();
+    });
+
+    it('throws after exhausting retries', async () => {
+      const create = vi.fn().mockRejectedValue({ status: 429, message: 'limit' });
+      const client = {
+        chat: { completions: { create } },
+      } as unknown as OpenAI;
+      await expect(
+        new OpenAiReviewProvider('test-key', 'test-model', client, {
+          maxRetries: 2,
+          backoffMs: () => 0,
+        }).review({ pullRequest: pullRequestFixture, batch }),
+      ).rejects.toThrow(/rate limit/);
+      expect(create).toHaveBeenCalledTimes(3);
+    });
+
+    it('uses the supplied backoff scheduler between attempts', async () => {
+      const create = vi
+        .fn()
+        .mockRejectedValueOnce({ status: 429, message: 'limit' })
+        .mockResolvedValueOnce({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ summary: 'ok', riskLevel: 'low', findings: [] }),
+              },
+            },
+          ],
+        });
+      const client = {
+        chat: { completions: { create } },
+      } as unknown as OpenAI;
+      const backoffMs = vi.fn().mockReturnValue(0);
+      await new OpenAiReviewProvider('test-key', 'test-model', client, {
+        maxRetries: 1,
+        backoffMs,
+      }).review({ pullRequest: pullRequestFixture, batch });
+      expect(backoffMs).toHaveBeenCalledWith(1, expect.objectContaining({ status: 429 }));
+    });
   });
 });

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -90,6 +90,35 @@ describe('GitHub client', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('retries transient GitHub API failures', async () => {
+    const getContent = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 502, message: 'bad gateway' })
+      .mockResolvedValueOnce({ data: { type: 'file', content: Buffer.from('ok').toString('base64') } });
+    const octokit = { repos: { getContent } } as never;
+    await expect(
+      new GithubClient({ octokit, retry: { maxRetries: 1, backoffMs: () => 0 } }).getFileAtRef(
+        reference,
+        '.oss-pr-reviewer.yml',
+        'base-sha',
+      ),
+    ).resolves.toBe('ok');
+    expect(getContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry GitHub 404 responses when reading files', async () => {
+    const getContent = vi.fn().mockRejectedValue({ status: 404 });
+    const octokit = { repos: { getContent } } as never;
+    await expect(
+      new GithubClient({ octokit, retry: { maxRetries: 3, backoffMs: () => 0 } }).getFileAtRef(
+        reference,
+        '.oss-pr-reviewer.yml',
+        'base-sha',
+      ),
+    ).resolves.toBeUndefined();
+    expect(getContent).toHaveBeenCalledOnce();
+  });
+
   it('normalizes PR comment list, create, and update API calls', async () => {
     const octokit = {
       issues: {


### PR DESCRIPTION
## Summary

- Retry transient OpenAI 429/5xx responses with bounded exponential backoff (default: 2 retries).
- Retry transient GitHub failures while reading trusted-base repository configuration.
- Keep non-retryable 4xx responses and comment writes single-shot.

This PR is rebased onto the current `main` and supersedes #24. It intentionally does not close #18: bounded batch concurrency is a separate follow-up so retry behavior remains independently reviewable.

## Validation

- npm test -- --run (91 passed)
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

## Limitations

- The retry policy is limited to HTTP 429 and 5xx responses and does not yet honor provider-specific `Retry-After` headers.
- Live OpenAI/GitHub API smoke testing was not performed.