### PR TITLE
fix(review): bound concurrent batch requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Fetch pull request metadata and changed files with Octokit.
 - Skip binary, patchless, and oversized files with reasons in the report.
 - Batch large text diffs with fixed limits: 60,000 characters, 30,000 characters per file, and 8 files per batch.
+- Limit provider calls to four concurrent review batches and preserve result ordering.
 - Validate OpenAI JSON responses with Zod.
 - Deduplicate identical findings and apply deterministic severity filtering.
 - Print Markdown to stdout or write it to `--output`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,7 @@ Markdown renderer
 - `src/review/normalize.ts` removes binary and patchless files from AI input while preserving skip reasons for the report.
 - `src/review/batching.ts` applies centralized diff, file, batch, and reserved-context limits through `ReviewBudget`.
 - `src/review/batching.ts` exposes an explicit character-based budget with reserved prompt/response space while retaining the v0.1 legacy batching shape.
+- `src/review/reviewer.ts` processes batches with a four-worker pool, preserves input order, and stops scheduling new batches after a provider failure while allowing active calls to settle.
 - `src/ai/` contains the OpenAI SDK boundary. The rest of the review engine depends on the small `ReviewProvider` interface.
 - `src/review/schema.ts` validates every provider response before it enters the merge pipeline.
 - `src/report/` renders the final report without making claims that automated review is definitive.

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -2,6 +2,7 @@ import type { PullRequest, ReviewResult, Severity, SkippedFile } from '../types.
 import type { RepositoryConfig } from '../config/repository.js';
 import { DEFAULT_REPOSITORY_CONFIG, getConfiguredReviewBudget } from '../config/repository.js';
 import { createBatches, DEFAULT_REVIEW_BUDGET } from './batching.js';
+import type { ReviewBatch } from './batching.js';
 import { filterIgnoredFiles } from './ignore.js';
 import { normalizeFiles } from './normalize.js';
 import { deduplicateFindings, filterFindings, severityOrder } from './severity.js';
@@ -15,6 +16,8 @@ export interface ReviewExecution {
   ignoredFileCount: number;
   batchCount: number;
 }
+
+export const DEFAULT_REVIEW_CONCURRENCY = 4;
 
 export async function reviewPullRequest(
   pullRequest: PullRequest,
@@ -45,10 +48,11 @@ export async function reviewPullRequest(
     };
   }
 
-  const results = await Promise.all(
-    batched.batches.map((batch) =>
-      provider.review({ pullRequest, batch, reviewRules: repositoryConfig.rules }),
-    ),
+  const results = await reviewBatches(
+    batched.batches,
+    provider,
+    pullRequest,
+    repositoryConfig.rules,
   );
   const findings = filterFindings(
     deduplicateFindings(results.flatMap((result) => result.findings)),
@@ -77,4 +81,40 @@ export async function reviewPullRequest(
     ignoredFileCount: ignored.skipped.length,
     batchCount: batched.batches.length,
   };
+}
+
+async function reviewBatches(
+  batches: ReviewBatch[],
+  provider: ReviewProvider,
+  pullRequest: PullRequest,
+  reviewRules: RepositoryConfig['rules'],
+): Promise<ReviewResult[]> {
+  const results = new Array<ReviewResult>(batches.length);
+  let nextIndex = 0;
+  let failed = false;
+  let firstError: unknown;
+
+  const worker = async (): Promise<void> => {
+    while (!failed) {
+      const index = nextIndex++;
+      if (index >= batches.length) return;
+
+      try {
+        results[index] = await provider.review({
+          pullRequest,
+          batch: batches[index],
+          reviewRules,
+        });
+      } catch (error) {
+        failed = true;
+        firstError = error;
+        return;
+      }
+    }
+  };
+
+  const workerCount = Math.min(DEFAULT_REVIEW_CONCURRENCY, batches.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  if (failed) throw firstError;
+  return results;
 }

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createBatches, REVIEW_LIMITS } from '../src/review/batching.js';
 import { normalizeFiles } from '../src/review/normalize.js';
-import { reviewPullRequest } from '../src/review/reviewer.js';
+import { DEFAULT_REVIEW_CONCURRENCY, reviewPullRequest } from '../src/review/reviewer.js';
 import { deduplicateFindings, filterFindings, severityOrder } from '../src/review/severity.js';
 import { findingFixture, pullRequestFixture, resultFixture } from './fixtures.js';
 import type { ReviewProvider } from '../src/ai/provider.js';
@@ -177,5 +177,86 @@ describe('review pipeline', () => {
         reviewRules: [{ id: 'require-tests', description: 'Changes to source need tests.' }],
       }),
     );
+  });
+
+  it('limits concurrent provider calls and preserves batch order', async () => {
+    const files = Array.from({ length: 10 }, (_, index) => ({
+      path: `batch-${index}.ts`,
+      status: 'modified',
+      additions: 1,
+      deletions: 0,
+      patch: 'x',
+    }));
+    let active = 0;
+    let maxActive = 0;
+    const provider: ReviewProvider = {
+      review: async ({ batch }) => {
+        const index = Number(batch.files[0]?.path.match(/batch-(\d+)/)?.[1]);
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => globalThis.setTimeout(resolve, 10 - index));
+        active -= 1;
+        return resultFixture({ summary: `batch ${index}`, findings: [] });
+      },
+    };
+    const execution = await reviewPullRequest(
+      { ...pullRequestFixture, files },
+      provider,
+      'low',
+      {
+        ...DEFAULT_REPOSITORY_CONFIG,
+        context: {
+          maxFilesPerBatch: 1,
+          maxDiffCharacters: 10,
+          maxFileCharacters: 10,
+          reservedPromptCharacters: 0,
+          reservedResponseCharacters: 0,
+        },
+      },
+    );
+
+    expect(maxActive).toBeLessThanOrEqual(DEFAULT_REVIEW_CONCURRENCY);
+    expect(execution.result.summary).toBe(
+      'batch 0 batch 1 batch 2 batch 3 batch 4 batch 5 batch 6 batch 7 batch 8 batch 9',
+    );
+  });
+
+  it('stops scheduling new batches after the first provider failure', async () => {
+    const files = Array.from({ length: 10 }, (_, index) => ({
+      path: `batch-${index}.ts`,
+      status: 'modified',
+      additions: 1,
+      deletions: 0,
+      patch: 'x',
+    }));
+    const calls: number[] = [];
+    const provider: ReviewProvider = {
+      review: async ({ batch }) => {
+        const index = Number(batch.files[0]?.path.match(/batch-(\d+)/)?.[1]);
+        calls.push(index);
+        if (index === 1) throw new Error('provider failed');
+        await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+        return resultFixture({ findings: [] });
+      },
+    };
+
+    await expect(
+      reviewPullRequest(
+        { ...pullRequestFixture, files },
+        provider,
+        'low',
+        {
+          ...DEFAULT_REPOSITORY_CONFIG,
+          context: {
+            maxFilesPerBatch: 1,
+            maxDiffCharacters: 10,
+            maxFileCharacters: 10,
+            reservedPromptCharacters: 0,
+            reservedResponseCharacters: 0,
+          },
+        },
+      ),
+    ).rejects.toThrow('provider failed');
+    expect(calls.sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
   });
 });


### PR DESCRIPTION
## Summary

- Process review batches through a four-worker pool instead of starting every provider call at once.
- Preserve input batch order in the merged report even when workers finish out of order.
- Stop scheduling new batches after the first provider failure while allowing in-flight calls to settle; the existing fail-the-review error semantics remain unchanged.
- Document the concurrency boundary and add regression tests for max active calls, ordering, and failure stop behavior.

Implements the bounded-concurrency portion of issue #18. Retry/backoff is already merged in #26 and remains a separate concern.

## Validation

- npm test -- --run (93 passed)
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

## Limitations

- The default concurrency is a code-level constant of 4; configuration exposure can be added later if real workloads require it.
- No live OpenAI API smoke test was performed.