### PR TITLE
fix(action): bound job summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 - Add repository-specific review rules and ignore paths without changing application code.
 - Reserve predictable prompt/response space with simple character-based context budget settings.
-- Run an opt-in GitHub Action that appends advisory reports to the Actions job summary.
+- Run an opt-in GitHub Action that appends a bounded advisory report to the Actions job summary.
 
 ## How It Works
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -94,7 +94,7 @@ The existing `.oss-pr-reviewer.yml` is loaded from the pull request base commit.
 
 ## Output and Limitations
 
-The full report is always appended to the Actions job summary. Comment mode reuses the report, applies a 60,000-character safety limit, preserves higher-priority findings when shortening, neutralizes mention-like text, and adds a truncation notice when needed. It does not create annotations or enforce a merge policy. Live GitHub/OpenAI credentials are not needed for repository tests, but a real Action run requires valid secrets and network access.
+The Action writes the complete report to its runner-temp report path and appends a deterministic summary capped at 900 KiB (UTF-8 bytes) to `GITHUB_STEP_SUMMARY`. When the cap is reached, the summary preserves the report header and prioritizes critical/high findings before lower-severity findings and supporting sections, then adds an explicit truncation notice. Comment mode reuses the report, applies a separate 60,000-character safety limit, preserves higher-priority findings when shortening, and neutralizes mention-like text. The Action does not upload the full report as an artifact or create annotations. Live GitHub/OpenAI credentials are not needed for repository tests, but a real Action run requires valid secrets and network access.
 
 ## Troubleshooting
 

--- a/src/action/output.ts
+++ b/src/action/output.ts
@@ -1,5 +1,6 @@
 import { appendFile, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
+import { boundSummary } from './summary.js';
 
 export async function writeActionReport(
   report: string,
@@ -7,7 +8,7 @@ export async function writeActionReport(
   summaryPath?: string,
 ): Promise<void> {
   await writeFile(reportPath, report, 'utf8');
-  if (summaryPath) await appendFile(summaryPath, `${report.trimEnd()}\n`, 'utf8');
+  if (summaryPath) await appendFile(summaryPath, boundSummary(report), 'utf8');
 }
 
 export async function writeActionOutput(

--- a/src/action/summary.ts
+++ b/src/action/summary.ts
@@ -1,0 +1,113 @@
+import { Buffer } from 'node:buffer';
+
+export const DEFAULT_SUMMARY_BUDGET_BYTES = 900 * 1024;
+export const SUMMARY_TRUNCATION_NOTICE =
+  '> This job summary was shortened because the complete review exceeded the summary size limit. The complete report is not shown here.';
+
+const FINDING_PRIORITIES = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN'];
+
+export function boundSummary(report: string, budgetBytes = DEFAULT_SUMMARY_BUDGET_BYTES): string {
+  if (budgetBytes <= 0) throw new Error('Summary budget must be positive.');
+
+  const normalized = report.trimEnd();
+  const complete = `${normalized}\n`;
+  if (byteLength(complete) <= budgetBytes) return complete;
+
+  const sections = splitReport(normalized);
+  const notice = `\n\n${SUMMARY_TRUNCATION_NOTICE}\n`;
+  if (byteLength(notice) > budgetBytes) return truncateUtf8(notice, budgetBytes);
+  const findings = sortFindings(sections.findings);
+  const available = Math.max(0, budgetBytes - byteLength(notice));
+  const priorityFinding = findings.find((finding) => findingPriority(finding) <= 1);
+  const reservedPriority = priorityFinding ? byteLength(priorityFinding) + 2 : 0;
+  const heading = `${sections.findingsHeading}`;
+  const headerBudget = Math.max(
+    0,
+    available - byteLength(heading) - 2 - Math.min(reservedPriority, Math.floor(available / 2)),
+  );
+  const boundedHeader = truncateUtf8(sections.header, headerBudget).trimEnd();
+  let selected = boundedHeader ? `${boundedHeader}\n\n${heading}` : heading;
+
+  const chunks = [sections.findingsIntro, ...findings, sections.supporting].filter(Boolean);
+  for (const chunk of chunks) {
+    const candidate = `${selected}\n\n${chunk}`;
+    if (byteLength(`${candidate}${notice}`) <= budgetBytes) selected = candidate;
+  }
+
+  const bounded = truncateUtf8(selected, available).trimEnd();
+  return `${bounded}${notice}`;
+}
+
+interface ReportSections {
+  header: string;
+  findingsHeading: string;
+  findingsIntro: string;
+  findings: string[];
+  supporting: string;
+}
+
+function splitReport(report: string): ReportSections {
+  const lines = report.split('\n');
+  const findingsIndex = lines.findIndex((line) => line === '## Findings');
+  if (findingsIndex < 0) {
+    return {
+      header: truncateUtf8(report, report.length),
+      findingsHeading: '',
+      findingsIntro: '',
+      findings: [],
+      supporting: '',
+    };
+  }
+
+  const supportingIndex = lines.findIndex(
+    (line, index) => index > findingsIndex && /^## (Review Statistics|Skipped Files)$/.test(line),
+  );
+  const findingsEnd = supportingIndex >= 0 ? supportingIndex : lines.length;
+  const header = lines.slice(0, findingsIndex).join('\n').trim();
+  const findingsLines = lines.slice(findingsIndex + 1, findingsEnd);
+  const findingBlocks: string[][] = [];
+  let current: string[] = [];
+  for (const line of findingsLines) {
+    if (line.startsWith('### ') && current.length > 0) {
+      findingBlocks.push(current);
+      current = [];
+    }
+    current.push(line);
+  }
+  if (current.length > 0) findingBlocks.push(current);
+
+  const findings = findingBlocks
+    .map((block) => block.join('\n').trim())
+    .filter((block) => block.length > 0 && !/^No significant issues/.test(block));
+  const findingsIntro = findingBlocks
+    .filter((block) => !block.some((line) => line.startsWith('### ')))
+    .map((block) => block.join('\n').trim())
+    .filter(Boolean)
+    .join('\n\n');
+  const supporting = supportingIndex >= 0 ? lines.slice(supportingIndex).join('\n').trim() : '';
+
+  return { header, findingsHeading: '## Findings', findingsIntro, findings, supporting };
+}
+
+function sortFindings(findings: string[]): string[] {
+  return findings
+    .map((finding, index) => ({ finding, index, priority: findingPriority(finding) }))
+    .sort((a, b) => a.priority - b.priority || a.index - b.index)
+    .map(({ finding }) => finding);
+}
+
+function findingPriority(finding: string): number {
+  const heading = finding.match(/^### ([A-Z]+)/m)?.[1] ?? 'UNKNOWN';
+  const priority = FINDING_PRIORITIES.indexOf(heading);
+  return priority < 0 ? FINDING_PRIORITIES.length : priority;
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  if (byteLength(value) <= maxBytes) return value;
+  return Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8');
+}

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
 
 import {
   buildActionReviewOptions,
@@ -8,6 +9,11 @@ import {
 import { parsePullRequestEvent } from '../src/action/event.js';
 import { writeActionReport } from '../src/action/output.js';
 import { writeActionOutput } from '../src/action/output.js';
+import {
+  boundSummary,
+  DEFAULT_SUMMARY_BUDGET_BYTES,
+  SUMMARY_TRUNCATION_NOTICE,
+} from '../src/action/summary.js';
 import { assertActionCredentialsAvailable } from '../src/action/security.js';
 import { publishActionComment } from '../src/action/comment.js';
 import { OSS_PR_REVIEWER_MARKER } from '../src/github/comments.js';
@@ -204,6 +210,67 @@ describe('GitHub Action report output', () => {
 
     await expect(readFile(reportPath, 'utf8')).resolves.toBe('# Report\n');
     await expect(readFile(summaryPath, 'utf8')).resolves.toBe('# Report\n');
+  });
+
+  it('bounds oversized summaries by UTF-8 bytes and prioritizes severe findings', () => {
+    const report = [
+      '# PR Review Report',
+      '',
+      '## Pull Request',
+      '',
+      '- Title: 漢字',
+      '',
+      '## Findings',
+      '',
+      '### LOW - Bug',
+      '',
+      'low finding '.repeat(30),
+      '',
+      '### CRITICAL - Security',
+      '',
+      'critical finding',
+      '',
+      '## Review Statistics',
+      '',
+      '- Findings: 2',
+    ].join('\n');
+    const summary = boundSummary(report, 300);
+
+    expect(Buffer.byteLength(summary, 'utf8')).toBeLessThanOrEqual(300);
+    expect(summary).toContain('CRITICAL - Security');
+    expect(summary).toContain(SUMMARY_TRUNCATION_NOTICE);
+    expect(Buffer.byteLength(summary, 'utf8')).toBeLessThanOrEqual(DEFAULT_SUMMARY_BUDGET_BYTES);
+  });
+
+  it('retains the report header and critical findings when the summary is oversized', () => {
+    const report = [
+      '# PR Review Report',
+      '',
+      '## Pull Request',
+      '',
+      '- Title: Large summary',
+      '',
+      '## Summary',
+      '',
+      'x'.repeat(5_000),
+      '',
+      '## Findings',
+      '',
+      '### LOW - Bug',
+      '',
+      'low finding',
+      '',
+      '### CRITICAL - Security',
+      '',
+      'critical finding',
+    ].join('\n');
+    const summary = boundSummary(report, 500);
+
+    expect(summary).toContain('# PR Review Report');
+    expect(summary).toContain('## Findings');
+    expect(summary).toContain('CRITICAL - Security');
+    expect(summary).toContain(SUMMARY_TRUNCATION_NOTICE);
+    expect(Buffer.byteLength(summary, 'utf8')).toBeLessThanOrEqual(500);
   });
 
   it('writes stable action outputs using the GitHub output protocol', async () => {


### PR DESCRIPTION
## Summary

- Cap `GITHUB_STEP_SUMMARY` output at 900 KiB measured in UTF-8 bytes.
- Preserve the report header and prioritize critical/high findings before lower-severity findings and supporting sections.
- Append an explicit notice whenever the summary is shortened.
- Keep the complete report write to the runner-temp path unchanged; artifact upload remains out of scope.
- Add regression coverage for byte limits, multibyte text, severe-finding priority, and oversized summary headers.

Implements the clarified behavior for issue #19.

## Validation

- npm test -- --run (95 passed)
- npm run typecheck
- npm run lint
- npm run build
- npx prettier --check (changed files)
- git diff --check

## Limitations

- The 900 KiB budget is a fixed default in this release.
- The complete report is not uploaded as an artifact.