### PR TITLE
fix: report incomplete reviews for truncated GitHub file lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Pull request review often starts with the same context-gathering work: finding t
 
 - Review by `--repo owner/repository --pr 123` or a GitHub pull request URL.
 - Fetch pull request metadata and changed files with Octokit.
+- Detect truncated GitHub file lists and mark the report explicitly incomplete.
 - Skip binary, patchless, and oversized files with reasons in the report.
 - Batch large text diffs with fixed limits: 60,000 characters, 30,000 characters per file, and 8 files per batch.
 - Limit provider calls to four concurrent review batches and preserve result ordering.
@@ -189,7 +190,8 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 
 - Only OpenAI is implemented as a provider.
 - The tool reviews supplied pull request metadata and patches rather than the full repository.
-- GitHub-truncated, missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
+- GitHub returns at most 3,000 pull-request files. When its changed-file count is larger than the returned list, the report continues with an explicit incomplete status, warning, and unavailable-file count.
+- Missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
 - Context budgeting uses character approximations rather than exact model tokenization.
 - The GitHub Action does not create annotations or enforce a merge policy. Comment mode is bounded and advisory; the CLI does not clone repositories or run tests.
 - Live API usage requires network access and valid credentials; automated tests use mocks.

--- a/docs/review-format.md
+++ b/docs/review-format.md
@@ -2,7 +2,7 @@
 
 The CLI emits a structured report with pull request metadata, an overall summary and risk, findings, review statistics, skipped files, and an automation disclaimer. The report includes statistics such as files changed, files ignored by configuration, and review batches. The GitHub Action places the same report in the Actions job summary.
 
-By default the report is rendered as Markdown. `--output-format json` emits the same `ReviewReportData` shape as deterministic JSON for CI integration and downstream tooling. The JSON contains `pullRequest`, `result` (with `summary`, `riskLevel`, and `findings`), `skippedFiles`, and the same count fields as the Markdown statistics block. Findings with `riskLevel: unknown` mean no review was performed (no reviewable patches or all findings filtered out).
+By default the report is rendered as Markdown. `--output-format json` emits the same `ReviewReportData` shape as deterministic JSON for CI integration and downstream tooling. The JSON contains `pullRequest`, `result` (with `summary`, `riskLevel`, and `findings`), `skippedFiles`, and the same count fields as the Markdown statistics block. `fileListStatus` is `complete` or `incomplete`, while `truncatedFileCount` records changed files that GitHub did not return. Findings with `riskLevel: unknown` mean no review was performed (no reviewable patches or all findings filtered out).
 
 ## Severity
 
@@ -27,3 +27,5 @@ Each finding includes a title, file, optional line, evidence-based explanation, 
 ## Interpretation
 
 Read findings as maintainer leads for further investigation. The model sees the pull request metadata, trusted-base repository guidance, and reviewable patches only. Missing context, truncated patches, generated files, binary files, deleted files, ignored files, and oversized content can limit accuracy. Automated output does not replace human review, testing, or a security audit.
+
+GitHub returns at most 3,000 files from the pull-request files endpoint. The reviewer compares that response with GitHub's authoritative changed-file count. If files are unavailable, the report continues but displays a prominent incomplete-review warning and a separate unavailable-file count. Unavailable files are not represented as ordinary skipped files, and the tool does not imply that pagination recovered them.

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -57,6 +57,7 @@ export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
         title: pullResponse.data.title,
         body: pullResponse.data.body ?? '',
         baseSha: pullResponse.data.base.sha,
+        changedFileCount: pullResponse.data.changed_files,
         files: filesResponse.map((file) => ({
           path: file.filename,
           status: file.status,

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -11,6 +11,10 @@ export function renderMarkdown(data: ReviewReportData): string {
     skippedFiles.length === 0
       ? '- None'
       : skippedFiles.map((file) => `- \`${file.path}\`: ${file.reason}`).join('\n');
+  const completenessWarning =
+    data.fileListStatus === 'incomplete'
+      ? `\n> [!WARNING]\n> GitHub returned ${pullRequest.files.length} of ${data.changedFileCount} changed files. This review is incomplete: ${data.truncatedFileCount} files were unavailable and are not included in the skipped-files list.\n`
+      : '';
 
   return `# PR Review Report
 
@@ -20,6 +24,8 @@ export function renderMarkdown(data: ReviewReportData): string {
 - PR: #${pullRequest.number}
 - Title: ${pullRequest.title}
 - Risk: ${capitalize(result.riskLevel)}
+- File list: ${capitalize(data.fileListStatus)}
+${completenessWarning}
 
 ## Summary
 
@@ -33,6 +39,7 @@ ${findings}
 
 - Files reviewed: ${data.reviewedFileCount}
 - Files changed: ${data.changedFileCount}
+- Files unavailable: ${data.truncatedFileCount}
 - Files ignored: ${data.ignoredFileCount}
 - Files skipped: ${skippedFiles.length}
 - Review batches: ${data.batchCount}

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -13,6 +13,8 @@ export interface ReviewExecution {
   skippedFiles: SkippedFile[];
   reviewedFileCount: number;
   changedFileCount: number;
+  fileListStatus: 'complete' | 'incomplete';
+  truncatedFileCount: number;
   ignoredFileCount: number;
   batchCount: number;
 }
@@ -25,6 +27,12 @@ export async function reviewPullRequest(
   minimumSeverity: Severity = 'low',
   repositoryConfig: RepositoryConfig = DEFAULT_REPOSITORY_CONFIG,
 ): Promise<ReviewExecution> {
+  const truncatedFileCount = Math.max(
+    0,
+    pullRequest.changedFileCount - pullRequest.files.length,
+  );
+  const fileListStatus =
+    pullRequest.changedFileCount === pullRequest.files.length ? 'complete' : 'incomplete';
   const ignored = filterIgnoredFiles(pullRequest.files, repositoryConfig.ignore.paths);
   const normalized = normalizeFiles(ignored.files);
   const batched = createBatches(
@@ -42,7 +50,9 @@ export async function reviewPullRequest(
       },
       skippedFiles,
       reviewedFileCount: 0,
-      changedFileCount: pullRequest.files.length,
+      changedFileCount: pullRequest.changedFileCount,
+      fileListStatus,
+      truncatedFileCount,
       ignoredFileCount: ignored.skipped.length,
       batchCount: 0,
     };
@@ -77,7 +87,9 @@ export async function reviewPullRequest(
     result: { summary, riskLevel, findings },
     skippedFiles,
     reviewedFileCount: normalized.reviewable.length - batched.skipped.length,
-    changedFileCount: pullRequest.files.length,
+    changedFileCount: pullRequest.changedFileCount,
+    fileListStatus,
+    truncatedFileCount,
     ignoredFileCount: ignored.skipped.length,
     batchCount: batched.batches.length,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface PullRequest {
   title: string;
   body: string;
   baseSha: string;
+  changedFileCount: number;
   files: ChangedFile[];
 }
 
@@ -71,6 +72,8 @@ export interface ReviewReportData {
   skippedFiles: SkippedFile[];
   reviewedFileCount: number;
   changedFileCount: number;
+  fileListStatus: 'complete' | 'incomplete';
+  truncatedFileCount: number;
   ignoredFileCount: number;
   batchCount: number;
 }

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -7,6 +7,7 @@ export const pullRequestFixture: PullRequest = {
   title: 'Validate account access',
   body: 'Adds an authorization check.',
   baseSha: 'base-sha',
+  changedFileCount: 3,
   files: [
     {
       path: 'src/api/account.ts',

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -11,7 +11,7 @@ describe('GitHub client', () => {
     const octokit = {
       pulls: {
         get: vi.fn().mockResolvedValue({
-          data: { title: 'Title', body: null, base: { sha: 'base-sha' } },
+          data: { title: 'Title', body: null, base: { sha: 'base-sha' }, changed_files: 1 },
         }),
         listFiles: vi.fn(),
       },
@@ -36,8 +36,42 @@ describe('GitHub client', () => {
       number: 4,
       title: 'Title',
       body: '',
+      changedFileCount: 1,
     });
     expect(pullRequest.files[0]).toMatchObject({ path: 'src/a.ts', patch: '@@', additions: 2 });
+  });
+
+  it('retains the authoritative changed-file count when GitHub truncates the file list', async () => {
+    const octokit = {
+      pulls: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            title: 'Large change',
+            body: '',
+            base: { sha: 'base-sha' },
+            changed_files: 3001,
+          },
+        }),
+        listFiles: vi.fn(),
+      },
+      paginate: vi.fn().mockResolvedValue([
+        {
+          filename: 'src/available.ts',
+          status: 'modified',
+          additions: 1,
+          deletions: 0,
+          patch: '+available',
+        },
+      ]),
+    };
+
+    const pullRequest = await new GithubClient({ octokit: octokit as never }).getPullRequest(
+      reference,
+      4,
+    );
+
+    expect(pullRequest.changedFileCount).toBe(3001);
+    expect(pullRequest.files).toHaveLength(1);
   });
 
   it('normalizes authentication, rate limit, and not-found failures', async () => {

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -12,6 +12,8 @@ describe('Markdown report', () => {
       skippedFiles: [],
       reviewedFileCount: 2,
       changedFileCount: 2,
+      fileListStatus: 'complete',
+      truncatedFileCount: 0,
       ignoredFileCount: 0,
       batchCount: 1,
     });
@@ -30,6 +32,8 @@ describe('Markdown report', () => {
       skippedFiles: [{ path: 'logo.png', reason: 'binary' }],
       reviewedFileCount: 1,
       changedFileCount: 2,
+      fileListStatus: 'complete',
+      truncatedFileCount: 0,
       ignoredFileCount: 0,
       batchCount: 1,
     });
@@ -46,11 +50,32 @@ describe('Markdown report', () => {
       skippedFiles: [{ path: 'image.png', reason: 'binary asset' }],
       reviewedFileCount: 0,
       changedFileCount: 1,
+      fileListStatus: 'complete',
+      truncatedFileCount: 0,
       ignoredFileCount: 0,
       batchCount: 0,
     });
     expect(report).toContain('- Risk: Unknown');
     expect(report).toContain('No significant issues');
+  });
+  it('prominently marks truncated GitHub file lists as incomplete', () => {
+    const report = renderMarkdown({
+      pullRequest: { ...pullRequestFixture, changedFileCount: 3001 },
+      result: resultFixture({ findings: [] }),
+      skippedFiles: [],
+      reviewedFileCount: 1,
+      changedFileCount: 3001,
+      fileListStatus: 'incomplete',
+      truncatedFileCount: 2998,
+      ignoredFileCount: 0,
+      batchCount: 1,
+    });
+
+    expect(report).toContain('> [!WARNING]');
+    expect(report).toContain('GitHub returned 3 of 3001 changed files');
+    expect(report).toContain('This review is incomplete');
+    expect(report).toContain('Files unavailable: 2998');
+    expect(report).toContain('## Skipped Files\n\n- None');
   });
 });
 
@@ -66,6 +91,8 @@ describe('JSON report', () => {
     skippedFiles: [{ path: 'logo.png', reason: 'binary' }],
     reviewedFileCount: 1,
     changedFileCount: 2,
+    fileListStatus: 'complete' as const,
+    truncatedFileCount: 0,
     ignoredFileCount: 0,
     batchCount: 1,
   };
@@ -78,6 +105,8 @@ describe('JSON report', () => {
     expect(parsed.skippedFiles).toEqual([{ path: 'logo.png', reason: 'binary' }]);
     expect(parsed.reviewedFileCount).toBe(1);
     expect(parsed.changedFileCount).toBe(2);
+    expect(parsed.fileListStatus).toBe('complete');
+    expect(parsed.truncatedFileCount).toBe(0);
     expect(parsed.batchCount).toBe(1);
   });
 

--- a/tests/review.test.ts
+++ b/tests/review.test.ts
@@ -83,14 +83,30 @@ describe('review pipeline', () => {
     expect(execution.skippedFiles).toHaveLength(2);
     expect(execution.reviewedFileCount).toBe(1);
     expect(execution.changedFileCount).toBe(3);
+    expect(execution.fileListStatus).toBe('complete');
+    expect(execution.truncatedFileCount).toBe(0);
     expect(execution.ignoredFileCount).toBe(0);
     expect(execution.batchCount).toBe(1);
+  });
+
+  it('marks the review incomplete when GitHub returns fewer files than it reports', async () => {
+    const provider: ReviewProvider = { review: async () => resultFixture({ findings: [] }) };
+    const execution = await reviewPullRequest(
+      { ...pullRequestFixture, changedFileCount: 5 },
+      provider,
+    );
+
+    expect(execution.changedFileCount).toBe(5);
+    expect(execution.fileListStatus).toBe('incomplete');
+    expect(execution.truncatedFileCount).toBe(2);
+    expect(execution.skippedFiles).toHaveLength(2);
   });
   it('returns a useful empty result when no patches are reviewable', async () => {
     const provider: ReviewProvider = { review: async () => resultFixture() };
     const execution = await reviewPullRequest(
       {
         ...pullRequestFixture,
+        changedFileCount: 1,
         files: [{ path: 'image.png', status: 'modified', additions: 0, deletions: 0 }],
       },
       provider,


### PR DESCRIPTION
## Summary\n- retain GitHub's authoritative changed_files count\n- expose fileListStatus and truncatedFileCount in execution/report JSON\n- show a prominent Markdown warning without treating unavailable files as skipped\n- document the 3,000-file API limit and honest incomplete-review behavior\n\n## Validation\n- npm test -- --run (98 tests)\n- npm run typecheck\n- npm run lint\n- npm run build\n- git diff --check\n\nFixes #20