### PR TITLE
fix: skip stale pull request comment publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pull request review often starts with the same context-gathering work: finding t
 - Configure the default minimum severity with a trusted base-branch `.oss-pr-reviewer.yml` file.
 - Add repository-specific review rules and ignore paths without changing application code.
 - Reserve predictable prompt/response space with simple character-based context budget settings.
-- Run an opt-in GitHub Action that appends a bounded advisory report to the Actions job summary.
+- Run an opt-in GitHub Action that appends a bounded advisory report to the Actions job summary and publishes stale-safe comments.
 
 ## How It Works
 
@@ -110,7 +110,7 @@ The file is loaded from the pull request's base commit, not the PR branch, so a 
 
 ## GitHub Actions
 
-v0.4.0 adds an opt-in composite Action for `pull_request` events. It reuses the CLI, reads the trusted base-branch configuration, and always appends the Markdown report to the job summary. With `post-comment: true`, it also creates or updates one owned PR comment without posting duplicates.
+v0.4.0 adds an opt-in composite Action for `pull_request` events. It reuses the CLI, reads the trusted base-branch configuration, and always appends the Markdown report to the job summary. The documented workflows cancel older runs per pull request. With `post-comment: true`, it also creates or updates one owned PR comment, includes the reviewed head SHA, and skips publication when the current head has changed.
 
 ```yaml
 name: AI PR Review
@@ -194,6 +194,7 @@ Keep tokens in the environment, use authenticated GitHub access where possible, 
 - Missing, generated, binary, deleted, ignored, or oversized content can be skipped or reduce review context.
 - Context budgeting uses character approximations rather than exact model tokenization.
 - The GitHub Action does not create annotations or enforce a merge policy. Comment mode is bounded and advisory; the CLI does not clone repositories or run tests.
+- Comment publication is best-effort under concurrent runs: workflow cancellation and a current-head check reduce duplicates/stale overwrites, but GitHub comment creation has no atomic idempotency guarantee.
 - Live API usage requires network access and valid credentials; automated tests use mocks.
 
 ## Development and Testing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ Markdown renderer
 - `src/report/` renders the final report without making claims that automated review is definitive.
 - `action.yml` is a thin composite Action. It builds and runs only the trusted Action checkout, parses supported pull request event metadata, and appends the existing Markdown report to the job summary.
 - `src/action/` contains testable Action-boundary code for event parsing, input validation, secret redaction, fork limitations, and summary output. It does not duplicate review logic.
-- `src/github/comments.ts` owns marker-based comment discovery and create/update behavior. `src/github/comment-safety.ts` bounds and sanitizes comment output without changing the full summary report.
+- `src/github/comments.ts` owns marker-based comment discovery and create/update behavior, including a best-effort current-head check immediately before publication. `src/github/comment-safety.ts` bounds and sanitizes comment output without changing the full summary report.
 
 Custom rule descriptions are passed as untrusted user-context guidance. They cannot replace or modify the system review policy.
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -29,6 +29,8 @@ jobs:
 
 The example uses the tagged release rather than `main`. Pin the Action to a reviewed release or commit according to your repository's dependency policy.
 
+The examples use a per-repository, per-pull-request concurrency group with `cancel-in-progress: true`, so a newer push cancels an older queued or running review where GitHub can cancel it. The publisher also re-reads the current PR head immediately before creating or updating a comment and skips publication when the reviewed head SHA is stale. This is best-effort protection: GitHub's comment-create API has no compare-and-swap or idempotency key, so already-running concurrent creations cannot receive a strict duplicate guarantee.
+
 ## Choose an Output Mode
 
 Summary-only mode is the default and needs only read permissions:
@@ -54,7 +56,7 @@ steps:
       post-comment: true
 ```
 
-`post-comment` accepts only `true` or `false` and defaults to `false`. Comment mode creates one tool-owned comment on the first run and updates it on later `synchronize` runs. It uses the invisible marker `<!-- oss-pr-reviewer -->`, only targets expected bot-authored comments, and does not delete older duplicates.
+`post-comment` accepts only `true` or `false` and defaults to `false`. Comment mode creates one tool-owned comment on the first run and updates it on later `synchronize` runs. It uses the invisible marker `<!-- oss-pr-reviewer -->`, only targets expected bot-authored comments, includes the reviewed head SHA in the report, skips stale publications, and does not delete older duplicates.
 
 ## Inputs
 

--- a/examples/github-actions/basic.yml
+++ b/examples/github-actions/basic.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: oss-pr-reviewer-${{ github.repository }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/examples/github-actions/comment.yml
+++ b/examples/github-actions/comment.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: oss-pr-reviewer-${{ github.repository }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/src/action/comment.ts
+++ b/src/action/comment.ts
@@ -1,15 +1,16 @@
 import { parsePullRequestUrl } from '../github/types.js';
 import { publishReviewComment } from '../github/comments.js';
 import type { ReviewCommentClient, PublishedReviewComment } from '../github/comments.js';
+import type { PullRequestHeadClient } from '../github/comments.js';
 import type { PullRequestEvent } from './event.js';
 
 export async function publishActionComment(
-  client: ReviewCommentClient,
+  client: ReviewCommentClient & PullRequestHeadClient,
   event: PullRequestEvent,
   report: string,
   enabled: boolean,
 ): Promise<PublishedReviewComment | undefined> {
   if (!enabled) return undefined;
   const parsed = parsePullRequestUrl(event.url);
-  return publishReviewComment(client, parsed.repository, event.number, report);
+  return publishReviewComment(client, parsed.repository, event.number, report, event.headSha);
 }

--- a/src/action/event.ts
+++ b/src/action/event.ts
@@ -6,6 +6,7 @@ export interface PullRequestEvent {
   url: string;
   number: number;
   isFork: boolean;
+  headSha: string;
 }
 
 export function parsePullRequestEvent(value: unknown): PullRequestEvent {
@@ -19,7 +20,7 @@ export function parsePullRequestEvent(value: unknown): PullRequestEvent {
       number?: unknown;
       html_url?: unknown;
       base?: { repo?: { full_name?: unknown } };
-      head?: { repo?: { full_name?: unknown } };
+      head?: { repo?: { full_name?: unknown }; sha?: unknown };
     };
   };
   if (typeof event.action !== 'string' || !supportedActions.has(event.action)) {
@@ -27,6 +28,10 @@ export function parsePullRequestEvent(value: unknown): PullRequestEvent {
   }
   if (!event.pull_request || typeof event.pull_request.html_url !== 'string') {
     throw new Error('GitHub event is missing pull_request metadata.');
+  }
+  const headSha = event.pull_request.head?.sha;
+  if (typeof headSha !== 'string' || !headSha) {
+    throw new Error('GitHub event is missing pull_request head SHA.');
   }
 
   const parsed = parsePullRequestUrl(event.pull_request.html_url);
@@ -37,5 +42,5 @@ export function parsePullRequestEvent(value: unknown): PullRequestEvent {
   const headName = event.pull_request.head?.repo?.full_name;
   const isFork =
     typeof baseName === 'string' && typeof headName === 'string' && baseName !== headName;
-  return { url: event.pull_request.html_url, number: parsed.number, isFork };
+  return { url: event.pull_request.html_url, number: parsed.number, isFork, headSha };
 }

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -57,6 +57,7 @@ export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
         title: pullResponse.data.title,
         body: pullResponse.data.body ?? '',
         baseSha: pullResponse.data.base.sha,
+        headSha: pullResponse.data.head.sha,
         changedFileCount: pullResponse.data.changed_files,
         files: filesResponse.map((file) => ({
           path: file.filename,
@@ -67,6 +68,19 @@ export class GithubClient implements RepositoryFileReader, ReviewCommentClient {
           previousPath: file.previous_filename,
         })),
       };
+    } catch (error) {
+      throw normalizeGithubError(error);
+    }
+  }
+
+  async getPullRequestHeadSha(reference: RepositoryReference, number: number): Promise<string> {
+    try {
+      const response = await this.octokit.pulls.get({
+        owner: reference.owner,
+        repo: reference.repository,
+        pull_number: number,
+      });
+      return response.data.head.sha;
     } catch (error) {
       throw normalizeGithubError(error);
     }

--- a/src/github/comments.ts
+++ b/src/github/comments.ts
@@ -27,6 +27,10 @@ export interface ReviewCommentClient {
   ): Promise<Pick<ReviewComment, 'id' | 'htmlUrl'>>;
 }
 
+export interface PullRequestHeadClient {
+  getPullRequestHeadSha(reference: RepositoryReference, pullRequestNumber: number): Promise<string>;
+}
+
 export interface PublishedReviewComment {
   action: 'created' | 'updated';
   id: number;
@@ -55,14 +59,17 @@ export async function findReviewComment(
 }
 
 export async function publishReviewComment(
-  client: ReviewCommentClient,
+  client: ReviewCommentClient & PullRequestHeadClient,
   reference: RepositoryReference,
   pullRequestNumber: number,
   report: string,
-): Promise<PublishedReviewComment> {
+  reviewedHeadSha: string,
+): Promise<PublishedReviewComment | undefined> {
   const body = prepareReviewComment(report).body;
   const existing = await findReviewComment(client, reference, pullRequestNumber);
   try {
+    const currentHeadSha = await client.getPullRequestHeadSha(reference, pullRequestNumber);
+    if (currentHeadSha !== reviewedHeadSha) return undefined;
     if (existing) {
       const updated = await client.updateComment(reference, pullRequestNumber, existing.id, body);
       return { action: 'updated', id: updated.id, htmlUrl: updated.htmlUrl };

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -23,6 +23,7 @@ export function renderMarkdown(data: ReviewReportData): string {
 - Repository: ${pullRequest.owner}/${pullRequest.repository}
 - PR: #${pullRequest.number}
 - Title: ${pullRequest.title}
+- Reviewed head: \`${pullRequest.headSha}\`
 - Risk: ${capitalize(result.riskLevel)}
 - File list: ${capitalize(data.fileListStatus)}
 ${completenessWarning}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface PullRequest {
   title: string;
   body: string;
   baseSha: string;
+  headSha: string;
   changedFileCount: number;
   files: ChangedFile[];
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -100,12 +100,14 @@ describe('GitHub pull request event', () => {
         pull_request: {
           number: 12,
           html_url: 'https://github.com/octo/project/pull/12',
+          head: { sha: 'head-sha' },
         },
       }),
     ).toEqual({
       url: 'https://github.com/octo/project/pull/12',
       number: 12,
       isFork: false,
+      headSha: 'head-sha',
     });
   });
 
@@ -117,7 +119,7 @@ describe('GitHub pull request event', () => {
           number: 12,
           html_url: 'https://github.com/octo/project/pull/12',
           base: { repo: { full_name: 'octo/project' } },
-          head: { repo: { full_name: 'contributor/project' } },
+          head: { repo: { full_name: 'contributor/project' }, sha: 'head-sha' },
         },
       }).isFork,
     ).toBe(true);
@@ -131,7 +133,7 @@ describe('GitHub pull request event', () => {
           number: 12,
           html_url: 'https://github.com/octo/project/pull/12',
           base: { repo: { full_name: 'octo/project' } },
-          head: { repo: { full_name: 'octo/project' } },
+          head: { repo: { full_name: 'octo/project' }, sha: 'head-sha' },
         },
       }).isFork,
     ).toBe(false);
@@ -140,7 +142,12 @@ describe('GitHub pull request event', () => {
   it('explains why fork workflows cannot review without an OpenAI secret', () => {
     expect(() =>
       assertActionCredentialsAvailable(
-        { url: 'https://github.com/octo/project/pull/12', number: 12, isFork: true },
+        {
+          url: 'https://github.com/octo/project/pull/12',
+          number: 12,
+          isFork: true,
+          headSha: 'head-sha',
+        },
         {},
       ),
     ).toThrow(/does not expose repository secrets to pull_request workflows from forks/);
@@ -174,6 +181,9 @@ describe('GitHub Action security documentation', () => {
     expect(workflow).toMatch(/pull_request:/);
     expect(workflow).toMatch(/contents: read/);
     expect(workflow).toMatch(/pull-requests: read/);
+    expect(workflow).toMatch(/concurrency:/);
+    expect(workflow).toMatch(/cancel-in-progress: true/);
+    expect(workflow).toMatch(/github\.event\.pull_request\.number/);
     expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.4\.0/);
     expect(workflow).not.toMatch(/pull_request_target/);
   });
@@ -186,6 +196,8 @@ describe('GitHub Action security documentation', () => {
     expect(workflow).toMatch(/pull_request:/);
     expect(workflow).toMatch(/pull-requests: write/);
     expect(workflow).toMatch(/post-comment: true/);
+    expect(workflow).toMatch(/concurrency:/);
+    expect(workflow).toMatch(/cancel-in-progress: true/);
     expect(workflow).toMatch(/vuphongle\/oss-pr-reviewer@v0\.4\.0/);
     expect(workflow).not.toMatch(/pull_request_target/);
   });
@@ -289,7 +301,12 @@ describe('GitHub Action report output', () => {
     await expect(
       publishActionComment(
         client as never,
-        { url: 'https://github.com/octo/project/pull/7', number: 7, isFork: false },
+        {
+          url: 'https://github.com/octo/project/pull/7',
+          number: 7,
+          isFork: false,
+          headSha: 'head-sha',
+        },
         '## Review',
         false,
       ),
@@ -301,11 +318,17 @@ describe('GitHub Action report output', () => {
     const client = {
       listComments: vi.fn().mockResolvedValue([]),
       createComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
+      getPullRequestHeadSha: vi.fn().mockResolvedValue('head-sha'),
     };
     await expect(
       publishActionComment(
         client as never,
-        { url: 'https://github.com/octo/project/pull/7', number: 7, isFork: false },
+        {
+          url: 'https://github.com/octo/project/pull/7',
+          number: 7,
+          isFork: false,
+          headSha: 'head-sha',
+        },
         '## Review',
         true,
       ),

--- a/tests/comments.test.ts
+++ b/tests/comments.test.ts
@@ -38,9 +38,10 @@ describe('PR comment publishing', () => {
       listComments: vi.fn().mockResolvedValue([]),
       createComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
       updateComment: vi.fn(),
+      getPullRequestHeadSha: vi.fn().mockResolvedValue('head-sha'),
     };
 
-    await expect(publishReviewComment(client, reference, 7, '## Review')).resolves.toEqual({
+    await expect(publishReviewComment(client, reference, 7, '## Review', 'head-sha')).resolves.toEqual({
       action: 'created',
       id: 22,
       htmlUrl: 'https://example.test/c/22',
@@ -64,14 +65,15 @@ describe('PR comment publishing', () => {
       ]),
       createComment: vi.fn(),
       updateComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
+      getPullRequestHeadSha: vi.fn().mockResolvedValue('head-sha'),
     };
 
-    await expect(publishReviewComment(client, reference, 7, '## Updated')).resolves.toEqual({
+    await expect(publishReviewComment(client, reference, 7, '## Updated', 'head-sha')).resolves.toEqual({
       action: 'updated',
       id: 22,
       htmlUrl: 'https://example.test/c/22',
     });
-    await expect(publishReviewComment(client, reference, 7, '## Updated again')).resolves.toEqual({
+    await expect(publishReviewComment(client, reference, 7, '## Updated again', 'head-sha')).resolves.toEqual({
       action: 'updated',
       id: 22,
       htmlUrl: 'https://example.test/c/22',
@@ -106,14 +108,30 @@ describe('PR comment publishing', () => {
       listComments: vi.fn().mockResolvedValue([]),
       createComment: vi.fn().mockResolvedValue({ id: 22, htmlUrl: 'https://example.test/c/22' }),
       updateComment: vi.fn(),
+      getPullRequestHeadSha: vi.fn().mockResolvedValue('head-sha'),
     };
     const report = `# PR Review Report\n\n### CRITICAL - Security\n${'@maintainer critical '.repeat(4000)}`;
 
-    await publishReviewComment(client, reference, 7, report);
+    await publishReviewComment(client, reference, 7, report, 'head-sha');
 
     const body = client.createComment.mock.calls[0][2] as string;
     expect(body.length).toBeLessThanOrEqual(MAX_REVIEW_COMMENT_CHARACTERS);
     expect(body).toContain('@\u200bmaintainer');
     expect(body).toContain('shortened because the complete review exceeded');
+  });
+
+  it('skips publication when the pull request head changed during review', async () => {
+    const client = {
+      listComments: vi.fn().mockResolvedValue([]),
+      createComment: vi.fn(),
+      updateComment: vi.fn(),
+      getPullRequestHeadSha: vi.fn().mockResolvedValue('new-head'),
+    };
+
+    await expect(
+      publishReviewComment(client, reference, 7, '## Stale review', 'old-head'),
+    ).resolves.toBeUndefined();
+    expect(client.createComment).not.toHaveBeenCalled();
+    expect(client.updateComment).not.toHaveBeenCalled();
   });
 });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -7,6 +7,7 @@ export const pullRequestFixture: PullRequest = {
   title: 'Validate account access',
   body: 'Adds an authorization check.',
   baseSha: 'base-sha',
+  headSha: 'head-sha',
   changedFileCount: 3,
   files: [
     {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -11,7 +11,13 @@ describe('GitHub client', () => {
     const octokit = {
       pulls: {
         get: vi.fn().mockResolvedValue({
-          data: { title: 'Title', body: null, base: { sha: 'base-sha' }, changed_files: 1 },
+          data: {
+            title: 'Title',
+            body: null,
+            base: { sha: 'base-sha' },
+            head: { sha: 'head-sha' },
+            changed_files: 1,
+          },
         }),
         listFiles: vi.fn(),
       },
@@ -36,6 +42,7 @@ describe('GitHub client', () => {
       number: 4,
       title: 'Title',
       body: '',
+      headSha: 'head-sha',
       changedFileCount: 1,
     });
     expect(pullRequest.files[0]).toMatchObject({ path: 'src/a.ts', patch: '@@', additions: 2 });
@@ -49,6 +56,7 @@ describe('GitHub client', () => {
             title: 'Large change',
             body: '',
             base: { sha: 'base-sha' },
+            head: { sha: 'head-sha' },
             changed_files: 3001,
           },
         }),
@@ -88,6 +96,23 @@ describe('GitHub client', () => {
         new GithubClient({ octokit: octokit as never }).getPullRequest(reference, 4),
       ).rejects.toThrow(message);
     }
+  });
+
+  it('reads the current pull request head SHA for stale publication checks', async () => {
+    const octokit = {
+      pulls: {
+        get: vi.fn().mockResolvedValue({ data: { head: { sha: 'current-head' } } }),
+      },
+    };
+
+    await expect(
+      new GithubClient({ octokit: octokit as never }).getPullRequestHeadSha(reference, 4),
+    ).resolves.toBe('current-head');
+    expect(octokit.pulls.get).toHaveBeenCalledWith({
+      owner: 'octo',
+      repo: 'project',
+      pull_number: 4,
+    });
   });
 
   it('reads and decodes a file from a trusted ref', async () => {


### PR DESCRIPTION
## Summary\n- include reviewed head SHA in the pull request model and rendered report\n- add a current-head read immediately before comment create/update and skip stale reports\n- add per-pull-request cancel-in-progress concurrency to both documented workflows\n- document best-effort duplicate protection and GitHub's lack of comment idempotency\n\n## Validation\n- npm test -- --run (100 tests)\n- npm run typecheck\n- npm run lint\n- npm run build\n- git diff --check\n\nFixes #21